### PR TITLE
quality of life fixes

### DIFF
--- a/nvqm.c
+++ b/nvqm.c
@@ -1,14 +1,15 @@
-// (c) Copyright 2017, Sean Connelly (@voidqk), http://syntheti.cc
-// MIT License
-// Project Home: https://github.com/voidqk/nvqm
+/* (c) Copyright 2017, Sean Connelly (@voidqk), http://syntheti.cc
+ * MIT License
+ * Project Home: https://github.com/voidqk/nvqm
+ */
 
 #include "nvqm.h"
 
 #ifndef NVQM_SKIP_FLOATING_POINT
 
-//
-// mat3
-//
+/*
+ * mat3
+ */
 
 mat3 *mat3_add(mat3 *out, mat3 *a, mat3 *b){
 	out->v[0] = a->v[0] + b->v[0];
@@ -275,9 +276,9 @@ mat3 *mat3_transpose(mat3 *out, mat3 *a){
 	return out;
 }
 
-//
-// mat4
-//
+/*
+ * mat4
+ */
 
 mat4 *mat4_add(mat4 *out, mat4 *a, mat4 *b){
 	out->v[ 0] = a->v[ 0] + b->v[ 0];
@@ -922,7 +923,7 @@ mat4 *mat4_transpose(mat4 *out, mat4 *a){
 	return out;
 }
 
-#endif // NVQM_SKIP_FLOATING_POINT
+#endif /* NVQM_SKIP_FLOATING_POINT */
 
 #ifndef NVQM_SKIP_FIXED_POINT
 
@@ -931,7 +932,7 @@ xang xint_atan2(xint y, xint x){
 	if (y == 0 && x == 0)
 		return 0;
 	if (x == XINT1){
-		// hard-code some atan2(y, 1) values at the limits
+		/* hard-code some atan2(y, 1) values at the limits */
 		if (y <= -42722234) return (xang)3073;
 		if (y >=  42722235) return (xang)1023;
 	}
@@ -967,7 +968,7 @@ xang xint_acos(xint a){
 		return XANG180;
 	if (a >= XINT1)
 		return XANG0;
-	if (a > -51 && a < 51) // high error rate right around 0, so just do it manually
+	if (a > -51 && a < 51) /* high error rate right around 0, so just do it manually */
 		return XANG90;
 	xint res = xint_atan2(xint_div(xint_sqrt(xint_sub(XINT1, xint_mul(a, a))), a), XINT1);
 	if (a < 0)
@@ -980,18 +981,18 @@ xang xint_asin(xint a){
 		return XANG270;
 	if (a >= XINT1)
 		return XANG90;
-	if (a > -51 && a < 51) // high error rate right around 0, so just do it manually
+	if (a > -51 && a < 51) /* high error rate right around 0, so just do it manually */
 		return XANG0;
 	return xint_atan2(xint_div(a, xint_sqrt(xint_sub(XINT1, xint_mul(a, a)))), XINT1);
 }
 
 static inline int64_t x_mul31(int64_t res, int64_t f){
-	// res is Q33.31 and f is Q0.32
+	/* res is Q33.31 and f is Q0.32 */
 	return (int64_t)(((uint64_t)res * (uint64_t)f) >> 32);
 }
 
 static inline int64_t x_exp2f(int64_t f){
-	// res is Q33.31 and f is Q0.32
+	/* res is Q33.31 and f is Q0.32 */
 	static const int64_t
 		c0 = INT64_C(0x80000000),
 		c1 = INT64_C(0x58B45A41),
@@ -1006,8 +1007,9 @@ static inline int64_t x_exp2f(int64_t f){
 }
 
 static inline xint x_exp2(int64_t a){
-	// a is Q32.32
-	// 2^(whole+fraction) = 2^whole * 2^fraction
+	/* a is Q32.32
+	 * 2^(whole+fraction) = 2^whole * 2^fraction
+	 */
 	int32_t whole = a >> 32;
 	int64_t fract = x_exp2f(a & 0xFFFFFFFF);
 	if (whole < 15)
@@ -1027,7 +1029,7 @@ xint xint_exp(xint a){
 		neg = 1;
 		a = -a;
 	}
-	static const int64_t log2e = INT64_C(0x171547653); // log2(e) at Q32.32
+	static const int64_t log2e = INT64_C(0x171547653); /* log2(e) at Q32.32 */
 	xint res = x_exp2((log2e * (int64_t)a) >> 16);
 	if (neg)
 		res = xint_div(XINT1, res);
@@ -1039,7 +1041,7 @@ static inline int x_log2w(int w){
 	return (((int)(sizeof(int) * 8)) - __builtin_clz(w));
 }
 #elif defined(_MSC_VER)
-// TODO: actually test this
+/* TODO: actually test this */
 #include <intrin.h>
 static inline int x_log2w(int w){
 	return (((int)(sizeof(int) * 8)) - __lzcnt(w));
@@ -1066,7 +1068,7 @@ static inline int x_log2w(int w){
 }
 #endif
 
-static inline xint x_log2f(xint f){ // f ranges from (1, 2]
+static inline xint x_log2f(xint f){ /* f ranges from (1, 2] */
 	static const xint c1 = 0x16C40, c2 = INT32_C(0xFFFF6AFD), c3 = 0x28C2;
 	f = xint_sub(f, XINT1);
 	xint res = c3;
@@ -1084,7 +1086,7 @@ static inline xint x_log2(xint a){
 xint xint_log(xint a){
 	if (a <= 0)
 		return XINTMIN;
-	else if (a == 1) // must hard code these because it's too small to calculate
+	else if (a == 1) /* must hard code these because it's too small to calculate */
 		return INT32_C(0xFFF4E8DF);
 	else if (a == 2)
 		return INT32_C(0xFFF59A51);
@@ -1093,7 +1095,7 @@ xint xint_log(xint a){
 		small = 1;
 		a = xint_div(XINT1, a);
 	}
-	static const xint log2einv = 0xB172; // 1/(log2 e)
+	static const xint log2einv = 0xB172; /* 1/(log2 e) */
 	xint res = xint_mul(x_log2(a), log2einv);
 	if (small)
 		res = -res;
@@ -1110,7 +1112,7 @@ xint xint_pow(xint a, xint b){
 	if (b < 0){
 		b = -b;
 		if (a < XINT1)
-			a = xint_div(XINT1, a); // double flip -> no flip
+			a = xint_div(XINT1, a); /* double flip -> no flip */
 		else
 			flip = 1;
 	}
@@ -1119,10 +1121,11 @@ xint xint_pow(xint a, xint b){
 		flip = 1;
 	}
 
-	// res = a^(integer + fraction)
-	//     = a^(integer) * a^(fraction)
-	//     = a^(integer) * (2^(log2 a))^(fraction)
-	//     = a^(integer) * 2^(fraction * log2 a)
+	/* res = a^(integer + fraction)
+	 *     = a^(integer) * a^(fraction)
+	 *     = a^(integer) * (2^(log2 a))^(fraction)
+	 *     = a^(integer) * 2^(fraction * log2 a)
+	 */
 	xint res = XINT1;
 	xint base = a;
 	int pow_int = xint_toint(b);
@@ -1179,9 +1182,9 @@ xint xint_sqrt(xint a){
 	return res;
 }
 
-//
-// xmat3
-//
+/*
+ * xmat3
+ */
 
 xmat3 *xmat3_add(xmat3 *out, xmat3 *a, xmat3 *b){
 	out->v[0] = xint_add(a->v[0], b->v[0]);
@@ -1449,9 +1452,9 @@ xmat3 *xmat3_transpose(xmat3 *out, xmat3 *a){
 	return out;
 }
 
-//
-// xmat4
-//
+/*
+ * xmat4
+ */
 
 xmat4 *xmat4_add(xmat4 *out, xmat4 *a, xmat4 *b){
 	out->v[ 0] = xint_add(a->v[ 0], b->v[ 0]);
@@ -2151,7 +2154,7 @@ xmat4 *xmat4_transpose(xmat4 *out, xmat4 *a){
 	return out;
 }
 
-// sorry for the mess, but this is the lookup table for sin and tan
+/* sorry for the mess, but this is the lookup table for sin and tan */
 const xint xint_sin__lut[XANG360] = {
 	0, 101, 201, 302, 402, 503, 603, 704, 804, 905, 1005, 1106, 1206, 1307, 1407, 1508, 1608, 1709,
 	1809, 1910, 2010, 2111, 2211, 2312, 2412, 2513, 2613, 2714, 2814, 2914, 3015, 3115, 3216, 3316,
@@ -2654,4 +2657,4 @@ const xint xint_tan__lut[XANG180] = {
 	-1005, -905, -804, -704, -603, -503, -402, -302, -201, -101
 };
 
-#endif // NVQM_SKIP_FIXED_POINT
+#endif /* NVQM_SKIP_FIXED_POINT */

--- a/nvqm.h
+++ b/nvqm.h
@@ -1,19 +1,21 @@
-// (c) Copyright 2017, Sean Connelly (@voidqk), http://syntheti.cc
-// MIT License
-// Project Home: https://github.com/voidqk/nvqm
+/* (c) Copyright 2017, Sean Connelly (@voidqk), http://syntheti.cc
+ * MIT License
+ * Project Home: https://github.com/voidqk/nvqm
+ */
 
 #ifndef NVQM__H
 #define NVQM__H
 
 #ifndef NVQM_SKIP_FLOATING_POINT
-// floating point library included by default
-// define NVQM_SKIP_FLOATING_POINT to skip including the implementation
+/* floating point library included by default
+ * define NVQM_SKIP_FLOATING_POINT to skip including the implementation
+ */
 
 #include <math.h>
 
-//
-// 32-bit floating point
-//
+/*
+ * 32-bit floating point
+ */
 
 #ifndef NVQM_SKIP_COMPONENT_NAMES
 typedef union { float v[ 2]; struct { float x; float y; };                   struct { float r; float g; };                   struct { float s; float t; };                   } vec2;
@@ -116,9 +118,9 @@ static inline mat4 mat4_new(float v00, float v01, float v02, float v03, float v1
 static const float  TAU  = 6.28318530717958647692528676655900576839433879875021164195f;
 static const double TAUd = 6.28318530717958647692528676655900576839433879875021164195;
 
-//
-// num (scalars)
-//
+/*
+ * num (scalars)
+ */
 
 static inline float num_abs(float a){
 	return a < 0 ? -a : a;
@@ -200,9 +202,9 @@ static inline float num_tan(float a){
 	return tanf(a);
 }
 
-//
-// vec2
-//
+/*
+ * vec2
+ */
 
 static inline vec2 vec2_add(vec2 a, vec2 b){
 	return vec2_new(a.v[0] + b.v[0], a.v[1] + b.v[1]);
@@ -305,9 +307,9 @@ static inline vec2 vec2_sub(vec2 a, vec2 b){
 	return vec2_new(a.v[0] - b.v[0], a.v[1] - b.v[1]);
 }
 
-//
-// vec3
-//
+/*
+ * vec3
+ */
 
 static inline vec3 vec3_add(vec3 a, vec3 b){
 	return vec3_new(a.v[0] + b.v[0], a.v[1] + b.v[1], a.v[2] + b.v[2]);
@@ -433,7 +435,7 @@ static inline vec3 vec3_mul(vec3 a, vec3 b){
 	return vec3_new(a.v[0] * b.v[0], a.v[1] * b.v[1], a.v[2] * b.v[2]);
 }
 
-static inline float vec3_nangle(vec3 a, vec3 b){ // a and b are normalized
+static inline float vec3_nangle(vec3 a, vec3 b){ /* a and b are normalized */
 	float c = vec3_dot(a, b);
 	if (c < -1.0f || c > 1.0f)
 		return 0;
@@ -466,9 +468,9 @@ static inline vec3 vec3_sub(vec3 a, vec3 b){
 	return vec3_new(a.v[0] - b.v[0], a.v[1] - b.v[1], a.v[2] - b.v[2]);
 }
 
-//
-// vec4
-//
+/*
+ * vec4
+ */
 
 static inline vec4 vec4_add(vec4 a, vec4 b){
 	return vec4_new(a.v[0] + b.v[0], a.v[1] + b.v[1], a.v[2] + b.v[2], a.v[3] + b.v[3]);
@@ -594,9 +596,9 @@ static inline vec4 vec4_sub(vec4 a, vec4 b){
 	return vec4_new(a.v[0] - b.v[0], a.v[1] - b.v[1], a.v[2] - b.v[2], a.v[3] - b.v[3]);
 }
 
-//
-// quat
-//
+/*
+ * quat
+ */
 
 static inline quat quat_naxisang(vec3 axis, float ang);
 static inline quat quat_axisang(vec3 axis, float ang){
@@ -722,14 +724,14 @@ static inline quat quat_mul(quat a, quat b){
 	);
 }
 
-static inline quat quat_naxisang(vec3 axis, float ang){ // axis is normalized
+static inline quat quat_naxisang(vec3 axis, float ang){ /* axis is normalized */
 	ang *= 0.5f;
 	float s = num_sin(ang);
 	return quat_new(axis.v[0] * s, axis.v[1] * s, axis.v[2] * s, num_cos(ang));
 }
 
 static inline quat quat_normal(quat a);
-static inline quat quat_nbetween(vec3 from, vec3 to){ // from/to are normalized
+static inline quat quat_nbetween(vec3 from, vec3 to){ /* from/to are normalized */
 	float r = vec3_dot(from, to) + 1.0f;
 	vec3 cross;
 	if (r < 0.000001f){
@@ -791,9 +793,9 @@ static inline quat quat_slerp(quat a, quat b, float t){
 	);
 }
 
-//
-// mat2
-//
+/*
+ * mat2
+ */
 
 static inline mat2 mat2_add(mat2 a, mat2 b){
 	return mat2_new(a.v[0] + b.v[0], a.v[1] + b.v[1], a.v[2] + b.v[2], a.v[3] + b.v[3]);
@@ -860,9 +862,9 @@ static inline mat2 mat2_transpose(mat2 a){
 	return mat2_new(a.v[0], a.v[2], a.v[1], a.v[3]);
 }
 
-//
-// mat3x2
-//
+/*
+ * mat3x2
+ */
 
 static inline mat3x2 mat3x2_add(mat3x2 a, mat3x2 b){
 	return mat3x2_new(
@@ -975,9 +977,9 @@ static inline mat3x2 mat3x2_translation(vec2 a){
 	return mat3x2_new(1.0f, 0.0f, 0.0f, 1.0f, a.v[0], a.v[1]);
 }
 
-//
-// mat3
-//
+/*
+ * mat3
+ */
 
 mat3 *mat3_add        (mat3 *out, mat3 *a, mat3 *b);
 mat3 *mat3_adjoint    (mat3 *out, mat3 *a);
@@ -997,9 +999,9 @@ mat3 *mat3_translate  (mat3 *out, mat3 *a, vec2 b);
 mat3 *mat3_translation(mat3 *out, vec2 a);
 mat3 *mat3_transpose  (mat3 *out, mat3 *a);
 
-//
-// mat4
-//
+/*
+ * mat4
+ */
 
 mat4 *mat4_add           (mat4 *out, mat4 *a, mat4 *b);
 mat4 *mat4_adjoint       (mat4 *out, mat4 *a);
@@ -1025,19 +1027,20 @@ mat4 *mat4_translate     (mat4 *out, mat4 *a, vec3 b);
 mat4 *mat4_translation   (mat4 *out, vec3 a);
 mat4 *mat4_transpose     (mat4 *out, mat4 *a);
 
-#endif // NVQM_SKIP_FLOATING_POINT
+#endif /* NVQM_SKIP_FLOATING_POINT */
 
 #ifndef NVQM_SKIP_FIXED_POINT
-// fixed point library included by default
-// define NVQM_SKIP_FIXED_POINT to skip including the implementation
+/* fixed point library included by default
+ * define NVQM_SKIP_FIXED_POINT to skip including the implementation
+ */
 
-//
-// 16.16 fixed point library
-//
+/*
+ * 16.16 fixed point library
+ */
 
 #include <stdint.h>
 
-// signed 16.16 fixed-point
+/* signed 16.16 fixed-point */
 typedef int32_t xint;
 #ifndef NVQM_SKIP_COMPONENT_NAMES
 typedef union { xint v[ 2]; struct { xint x; xint y; };                 struct { xint r; xint g; };                 struct { xint s; xint t; };                 } xvec2;
@@ -1142,8 +1145,9 @@ static inline xmat4 xmat4_new(xint v00, xint v01, xint v02, xint v03, xint v10, 
 #define XINTMAX  INT32_MAX
 #define XINTMIN  INT32_MIN
 
-// note: angles for fixed-point operations are stored as 12 bit numbers (0 - 4095)
-// which means 0x000 = 0 degrees, 0x400 = 90 degrees, 0x800 = 180 degrees, etc
+/* note: angles for fixed-point operations are stored as 12 bit numbers (0 - 4095)
+ * which means 0x000 = 0 degrees, 0x400 = 90 degrees, 0x800 = 180 degrees, etc
+ */
 typedef int32_t xang;
 #define XANG0    0x0000
 #define XANG45   0x0200
@@ -1180,7 +1184,7 @@ static inline xint xint_fromdouble(double a){
 }
 
 static inline xang xang_wrap(xang a){
-	// this works because XANG360 is a power of 2
+	/* this works because XANG360 is a power of 2 */
 	return (uint32_t)a % XANG360;
 }
 
@@ -1282,9 +1286,9 @@ static inline xint xint_tan(xang a){
 	return xint_tan__lut[xang_wrap(a) >> 1];
 }
 
-//
-// xvec2
-//
+/*
+ * xvec2
+ */
 
 #ifndef NVQM_SKIP_FLOATING_POINT
 static inline vec2 xvec2_tovec2(xvec2 a){
@@ -1412,9 +1416,9 @@ static inline xvec2 xvec2_sub(xvec2 a, xvec2 b){
 	return xvec2_new(xint_sub(a.v[0], b.v[0]), xint_sub(a.v[1], b.v[1]));
 }
 
-//
-// xvec3
-//
+/*
+ * xvec3
+ */
 
 #ifndef NVQM_SKIP_FLOATING_POINT
 static inline vec3 xvec3_tovec3(xvec3 a){
@@ -1579,7 +1583,7 @@ static inline xvec3 xvec3_mul(xvec3 a, xvec3 b){
 	return xvec3_new(xint_mul(a.v[0], b.v[0]), xint_mul(a.v[1], b.v[1]), xint_mul(a.v[2], b.v[2]));
 }
 
-static inline xint xvec3_nangle(xvec3 a, xvec3 b){ // a and b are normalized
+static inline xint xvec3_nangle(xvec3 a, xvec3 b){ /* a and b are normalized */
 	return xint_acos(xvec3_dot(a, b));
 }
 
@@ -1601,7 +1605,7 @@ static inline xvec3 xvec3_normal(xvec3 a){
 }
 
 static inline xvec3 xvec3_orthogonal(xvec3 a, xvec3 b){
-	// normal the vectors before crossing them to prevent overflows
+	/* normal the vectors before crossing them to prevent overflows */
 	return xvec3_normal(xvec3_cross(xvec3_normal(a), xvec3_normal(b)));
 }
 
@@ -1613,9 +1617,9 @@ static inline xvec3 xvec3_sub(xvec3 a, xvec3 b){
 	return xvec3_new(xint_sub(a.v[0], b.v[0]), xint_sub(a.v[1], b.v[1]), xint_sub(a.v[2], b.v[2]));
 }
 
-//
-// xvec4
-//
+/*
+ * xvec4
+ */
 
 #ifndef NVQM_SKIP_FLOATING_POINT
 static inline vec4 xvec4_tovec4(xvec4 a){
@@ -1824,9 +1828,9 @@ static inline xvec4 xvec4_sub(xvec4 a, xvec4 b){
 	);
 }
 
-//
-// xquat
-//
+/*
+ * xquat
+ */
 
 #ifndef NVQM_SKIP_FLOATING_POINT
 static inline quat xquat_toquat(xquat a){
@@ -1981,7 +1985,7 @@ static inline xquat xquat_mul(xquat a, xquat b){
 	);
 }
 
-static inline xquat xquat_naxisang(xvec3 axis, xang ang){ // axis is normalized
+static inline xquat xquat_naxisang(xvec3 axis, xang ang){ /* axis is normalized */
 	ang >>= 1;
 	xint s = xint_sin(ang);
 	return xquat_new(
@@ -1993,7 +1997,7 @@ static inline xquat xquat_naxisang(xvec3 axis, xang ang){ // axis is normalized
 }
 
 static inline xquat xquat_normal(xquat a);
-static inline xquat xquat_nbetween(xvec3 from, xvec3 to){ // from/to are normalized
+static inline xquat xquat_nbetween(xvec3 from, xvec3 to){ /* from/to are normalized */
 	xint r = xint_add(xvec3_dot(from, to), XINT1);
 	xvec3 cross;
 	if (r <= 0){
@@ -2065,9 +2069,9 @@ static inline xquat xquat_slerp(xquat a, xquat b, xint t){
 	);
 }
 
-//
-// xmat2
-//
+/*
+ * xmat2
+ */
 
 #ifndef NVQM_SKIP_FLOATING_POINT
 static inline mat2 xmat2_tomat2(xmat2 a){
@@ -2184,9 +2188,9 @@ static inline xmat2 xmat2_transpose(xmat2 a){
 	return xmat2_new(a.v[0], a.v[2], a.v[1], a.v[3]);
 }
 
-//
-// xmat3x2
-//
+/*
+ * xmat3x2
+ */
 
 #ifndef NVQM_SKIP_FLOATING_POINT
 static inline mat3x2 xmat3x2_tomat3x2(xmat3x2 a){
@@ -2326,9 +2330,9 @@ static inline xmat3x2 xmat3x2_translation(xvec2 a){
 	return xmat3x2_new(XINT1, 0, 0, XINT1, a.v[0], a.v[1]);
 }
 
-//
-// xmat3
-//
+/*
+ * xmat3
+ */
 
 xmat3 *xmat3_add        (xmat3 *out, xmat3 *a, xmat3 *b);
 xmat3 *xmat3_adjoint    (xmat3 *out, xmat3 *a);
@@ -2348,9 +2352,9 @@ xmat3 *xmat3_translate  (xmat3 *out, xmat3 *a, xvec2 b);
 xmat3 *xmat3_translation(xmat3 *out, xvec2 a);
 xmat3 *xmat3_transpose  (xmat3 *out, xmat3 *a);
 
-//
-// xmat4
-//
+/*
+ * xmat4
+ */
 
 xmat4 *xmat4_add           (xmat4 *out, xmat4 *a, xmat4 *b);
 xmat4 *xmat4_adjoint       (xmat4 *out, xmat4 *a);
@@ -2376,6 +2380,6 @@ xmat4 *xmat4_translate     (xmat4 *out, xmat4 *a, xvec3 b);
 xmat4 *xmat4_translation   (xmat4 *out, xvec3 a);
 xmat4 *xmat4_transpose     (xmat4 *out, xmat4 *a);
 
-#endif // NVQM_SKIP_FIXED_POINT
+#endif /* NVQM_SKIP_FIXED_POINT */
 
-#endif // NVQM__H
+#endif /* NVQM__H */

--- a/nvqm.h
+++ b/nvqm.h
@@ -24,6 +24,88 @@ typedef struct { float v[ 6]; } mat3x2;
 typedef struct { float v[ 9]; } mat3;
 typedef struct { float v[16]; } mat4;
 
+static inline vec2 vec2_new(float x, float y){
+	vec2 res;
+	res.v[0] = x;
+	res.v[1] = y;
+	return res;
+}
+static inline vec3 vec3_new(float x, float y, float z){
+	vec3 res;
+	res.v[0] = x;
+	res.v[1] = y;
+	res.v[2] = z;
+	return res;
+}
+static inline vec4 vec4_new(float x, float y, float z, float w){
+	vec4 res;
+	res.v[0] = x;
+	res.v[1] = y;
+	res.v[2] = z;
+	res.v[3] = w;
+	return res;
+}
+static inline quat quat_new(float s, float i, float j, float k){
+	quat res;
+	res.v[0] = s;
+	res.v[1] = i;
+	res.v[2] = j;
+	res.v[3] = k;
+	return res;
+}
+
+static inline mat2 mat2_new(float v00, float v01, float v10, float v11){
+	mat2 res;
+	res.v[0] = v00;
+	res.v[1] = v01;
+	res.v[2] = v10;
+	res.v[3] = v11;
+	return res;
+}
+static inline mat3x2 mat3x2_new(float v00, float v01, float v10, float v11, float v20, float v21){
+	mat3x2 res;
+	res.v[0] = v00;
+	res.v[1] = v01;
+	res.v[2] = v10;
+	res.v[3] = v11;
+	res.v[4] = v20;
+	res.v[5] = v21;
+	return res;
+}
+static inline mat3 mat3_new(float v00, float v01, float v02, float v10, float v11, float v12, float v20, float v21, float v22){
+	mat3 res;
+	res.v[0] = v00;
+	res.v[1] = v01;
+	res.v[2] = v02;
+	res.v[3] = v10;
+	res.v[4] = v11;
+	res.v[5] = v12;
+	res.v[6] = v20;
+	res.v[7] = v21;
+	res.v[8] = v22;
+	return res;
+}
+static inline mat4 mat4_new(float v00, float v01, float v02, float v03, float v10, float v11, float v12, float v13, float v20, float v21, float v22, float v23, float v30, float v31, float v32, float v33){
+	mat4 res;
+	res.v[0] = v00;
+	res.v[1] = v01;
+	res.v[2] = v02;
+	res.v[3] = v03;
+	res.v[4] = v10;
+	res.v[5] = v11;
+	res.v[6] = v12;
+	res.v[7] = v13;
+	res.v[8] = v20;
+	res.v[9] = v21;
+	res.v[10] = v22;
+	res.v[11] = v23;
+	res.v[12] = v30;
+	res.v[13] = v31;
+	res.v[14] = v32;
+	res.v[15] = v33;
+	return res;
+}
+
 static const float  TAU  = 6.28318530717958647692528676655900576839433879875021164195f;
 static const double TAUd = 6.28318530717958647692528676655900576839433879875021164195;
 
@@ -116,31 +198,31 @@ static inline float num_tan(float a){
 //
 
 static inline vec2 vec2_add(vec2 a, vec2 b){
-	return (vec2){ a.v[0] + b.v[0], a.v[1] + b.v[1] };
+	return vec2_new(a.v[0] + b.v[0], a.v[1] + b.v[1]);
 }
 
 static inline vec2 vec2_applymat2(vec2 a, mat2 b){
 	float ax = a.v[0], ay = a.v[1];
-	return (vec2){ b.v[0] * ax + b.v[2] * ay, b.v[1] * ax + b.v[3] * ay };
+	return vec2_new(b.v[0] * ax + b.v[2] * ay, b.v[1] * ax + b.v[3] * ay);
 }
 
 static inline vec2 vec2_applymat3x2(vec2 a, mat3x2 b){
 	float ax = a.v[0], ay = a.v[1];
-	return (vec2){ b.v[0] * ax + b.v[2] * ay + b.v[4], b.v[1] * ax + b.v[3] * ay + b.v[5] };
+	return vec2_new(b.v[0] * ax + b.v[2] * ay + b.v[4], b.v[1] * ax + b.v[3] * ay + b.v[5]);
 }
 
 static inline vec2 vec2_applymat3(vec2 a, mat3 *b){
 	float ax = a.v[0], ay = a.v[1];
-	return (vec2){ b->v[0] * ax + b->v[3] * ay + b->v[6], b->v[1] * ax + b->v[4] * ay + b->v[7] };
+	return vec2_new(b->v[0] * ax + b->v[3] * ay + b->v[6], b->v[1] * ax + b->v[4] * ay + b->v[7]);
 }
 
 static inline vec2 vec2_applymat4(vec2 a, mat4 *b){
 	float ax = a.v[0], ay = a.v[1];
-	return (vec2){ b->v[0] * ax + b->v[4] * ay + b->v[12], b->v[1] * ax + b->v[5] * ay + b->v[13] };
+	return vec2_new(b->v[0] * ax + b->v[4] * ay + b->v[12], b->v[1] * ax + b->v[5] * ay + b->v[13]);
 }
 
 static inline vec2 vec2_clamp(vec2 a, vec2 min, vec2 max){
-	return (vec2){ num_clamp(a.v[0], min.v[0], max.v[0]), num_clamp(a.v[1], min.v[1], max.v[1]) };
+	return vec2_new(num_clamp(a.v[0], min.v[0], max.v[0]), num_clamp(a.v[1], min.v[1], max.v[1]));
 }
 
 static inline float vec2_cross(vec2 a, vec2 b){
@@ -158,7 +240,7 @@ static inline float vec2_dist2(vec2 a, vec2 b){
 }
 
 static inline vec2 vec2_div(vec2 a, vec2 b){
-	return (vec2){ a.v[0] / b.v[0], a.v[1] / b.v[1] };
+	return vec2_new(a.v[0] / b.v[0], a.v[1] / b.v[1]);
 }
 
 static inline float vec2_dot(vec2 a, vec2 b){
@@ -166,7 +248,7 @@ static inline float vec2_dot(vec2 a, vec2 b){
 }
 
 static inline vec2 vec2_inverse(vec2 a){
-	return (vec2){ 1.0f / a.v[0], 1.0f / a.v[1] };
+	return vec2_new(1.0f / a.v[0], 1.0f / a.v[1]);
 }
 
 static inline float vec2_len(vec2 a){
@@ -179,23 +261,23 @@ static inline float vec2_len2(vec2 a){
 }
 
 static inline vec2 vec2_lerp(vec2 a, vec2 b, float t){
-	return (vec2){ num_lerp(a.v[0], b.v[0], t), num_lerp(a.v[1], b.v[1], t) };
+	return vec2_new(num_lerp(a.v[0], b.v[0], t), num_lerp(a.v[1], b.v[1], t));
 }
 
 static inline vec2 vec2_max(vec2 a, vec2 b){
-	return (vec2){ num_max(a.v[0], b.v[0]), num_max(a.v[1], b.v[1]) };
+	return vec2_new(num_max(a.v[0], b.v[0]), num_max(a.v[1], b.v[1]));
 }
 
 static inline vec2 vec2_min(vec2 a, vec2 b){
-	return (vec2){ num_min(a.v[0], b.v[0]), num_min(a.v[1], b.v[1]) };
+	return vec2_new(num_min(a.v[0], b.v[0]), num_min(a.v[1], b.v[1]));
 }
 
 static inline vec2 vec2_mul(vec2 a, vec2 b){
-	return (vec2){ a.v[0] * b.v[0], a.v[1] * b.v[1] };
+	return vec2_new(a.v[0] * b.v[0], a.v[1] * b.v[1]);
 }
 
 static inline vec2 vec2_neg(vec2 a){
-	return (vec2){ -a.v[0], -a.v[1] };
+	return vec2_new(-a.v[0], -a.v[1]);
 }
 
 static inline vec2 vec2_normal(vec2 a){
@@ -203,17 +285,17 @@ static inline vec2 vec2_normal(vec2 a){
 		len = ax * ax + ay * ay;
 	if (len > 0.0f){
 		len = 1.0f / num_sqrt(len);
-		return (vec2){ ax * len, ay * len };
+		return vec2_new(ax * len, ay * len);
 	}
 	return a;
 }
 
 static inline vec2 vec2_scale(vec2 a, float s){
-	return (vec2){ a.v[0] * s, a.v[1] * s };
+	return vec2_new(a.v[0] * s, a.v[1] * s);
 }
 
 static inline vec2 vec2_sub(vec2 a, vec2 b){
-	return (vec2){ a.v[0] - b.v[0], a.v[1] - b.v[1] };
+	return vec2_new(a.v[0] - b.v[0], a.v[1] - b.v[1]);
 }
 
 //
@@ -221,7 +303,7 @@ static inline vec2 vec2_sub(vec2 a, vec2 b){
 //
 
 static inline vec3 vec3_add(vec3 a, vec3 b){
-	return (vec3){ a.v[0] + b.v[0], a.v[1] + b.v[1], a.v[2] + b.v[2] };
+	return vec3_new(a.v[0] + b.v[0], a.v[1] + b.v[1], a.v[2] + b.v[2]);
 }
 
 static inline float vec3_nangle(vec3 a, vec3 b);
@@ -232,20 +314,20 @@ static inline float vec3_angle(vec3 a, vec3 b){
 
 static inline vec3 vec3_applymat3x2(vec3 a, mat3x2 b){
 	float ax = a.v[0], ay = a.v[1], az = a.v[2];
-	return (vec3){
+	return vec3_new(
 		ax * b.v[0] + ay * b.v[2] + az * b.v[4],
 		ax * b.v[1] + ay * b.v[3] + az * b.v[5],
 		az
-	};
+	);
 }
 
 static inline vec3 vec3_applymat3(vec3 a, mat3 *b){
 	float ax = a.v[0], ay = a.v[1], az = a.v[2];
-	return (vec3){
+	return vec3_new(
 		ax * b->v[0] + ay * b->v[3] + az * b->v[6],
 		ax * b->v[1] + ay * b->v[4] + az * b->v[7],
 		ax * b->v[2] + ay * b->v[5] + az * b->v[8]
-	};
+	);
 }
 
 static inline vec3 vec3_applymat4(vec3 a, mat4 *b){
@@ -255,11 +337,11 @@ static inline vec3 vec3_applymat4(vec3 a, mat4 *b){
 		w = 1.0f;
 	else
 		w = 1.0f / w;
-	return (vec3){
+	return vec3_new(
 		(b->v[0] * ax + b->v[4] * ay + b->v[ 8] * az + b->v[12]) * w,
 		(b->v[1] * ax + b->v[5] * ay + b->v[ 9] * az + b->v[13]) * w,
 		(b->v[2] * ax + b->v[6] * ay + b->v[10] * az + b->v[14]) * w
-	};
+	);
 }
 
 static inline vec3 vec3_applyquat(vec3 a, quat b){
@@ -271,26 +353,26 @@ static inline vec3 vec3_applyquat(vec3 a, quat b){
 		iy =  bw * ay + bz * ax - bx * az,
 		iz =  bw * az + bx * ay - by * ax,
 		iw = -bx * ax - by * ay - bz * az;
-	return (vec3){
+	return vec3_new(
 		ix * bw + iw * -bx + iy * -bz - iz * -by,
 		iy * bw + iw * -by + iz * -bx - ix * -bz,
 		iz * bw + iw * -bz + ix * -by - iy * -bx
-	};
+	);
 }
 
 static inline vec3 vec3_clamp(vec3 a, vec3 min, vec3 max){
-	return (vec3){
+	return vec3_new(
 		num_clamp(a.v[0], min.v[0], max.v[0]),
 		num_clamp(a.v[1], min.v[1], max.v[1]),
 		num_clamp(a.v[2], min.v[2], max.v[2])
-	};
+	);
 }
 
 static inline vec3 vec3_cross(vec3 a, vec3 b){
 	float
 		ax = a.v[0], ay = a.v[1], az = a.v[2],
 		bx = b.v[0], by = b.v[1], bz = b.v[2];
-	return (vec3){ ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx };
+	return vec3_new(ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx);
 }
 
 static inline float vec3_len2(vec3 a);
@@ -304,7 +386,7 @@ static inline float vec3_dist2(vec3 a, vec3 b){
 }
 
 static inline vec3 vec3_div(vec3 a, vec3 b){
-	return (vec3){ a.v[0] / b.v[0], a.v[1] / b.v[1], a.v[2] / b.v[2] };
+	return vec3_new(a.v[0] / b.v[0], a.v[1] / b.v[1], a.v[2] / b.v[2]);
 }
 
 static inline float vec3_dot(vec3 a, vec3 b){
@@ -312,7 +394,7 @@ static inline float vec3_dot(vec3 a, vec3 b){
 }
 
 static inline vec3 vec3_inverse(vec3 a){
-	return (vec3){ 1.0f / a.v[0], 1.0f / a.v[1], 1.0f / a.v[2] };
+	return vec3_new(1.0f / a.v[0], 1.0f / a.v[1], 1.0f / a.v[2]);
 }
 
 static inline float vec3_len(vec3 a){
@@ -325,23 +407,23 @@ static inline float vec3_len2(vec3 a){
 }
 
 static inline vec3 vec3_lerp(vec3 a, vec3 b, float t){
-	return (vec3){
+	return vec3_new(
 		num_lerp(a.v[0], b.v[0], t),
 		num_lerp(a.v[1], b.v[1], t),
 		num_lerp(a.v[2], b.v[2], t)
-	};
+	);
 }
 
 static inline vec3 vec3_max(vec3 a, vec3 b){
-	return (vec3){ num_max(a.v[0], b.v[0]), num_max(a.v[1], b.v[1]), num_max(a.v[2], b.v[2]) };
+	return vec3_new(num_max(a.v[0], b.v[0]), num_max(a.v[1], b.v[1]), num_max(a.v[2], b.v[2]));
 }
 
 static inline vec3 vec3_min(vec3 a, vec3 b){
-	return (vec3){ num_min(a.v[0], b.v[0]), num_min(a.v[1], b.v[1]), num_min(a.v[2], b.v[2]) };
+	return vec3_new(num_min(a.v[0], b.v[0]), num_min(a.v[1], b.v[1]), num_min(a.v[2], b.v[2]));
 }
 
 static inline vec3 vec3_mul(vec3 a, vec3 b){
-	return (vec3){ a.v[0] * b.v[0], a.v[1] * b.v[1], a.v[2] * b.v[2] };
+	return vec3_new(a.v[0] * b.v[0], a.v[1] * b.v[1], a.v[2] * b.v[2]);
 }
 
 static inline float vec3_nangle(vec3 a, vec3 b){ // a and b are normalized
@@ -352,7 +434,7 @@ static inline float vec3_nangle(vec3 a, vec3 b){ // a and b are normalized
 }
 
 static inline vec3 vec3_neg(vec3 a){
-	return (vec3){ -a.v[0], -a.v[1], -a.v[2] };
+	return vec3_new(-a.v[0], -a.v[1], -a.v[2]);
 }
 
 static inline vec3 vec3_normal(vec3 a){
@@ -360,7 +442,7 @@ static inline vec3 vec3_normal(vec3 a){
 	float len = ax * ax + ay * ay + az * az;
 	if (len > 0.0f){
 		len = 1.0f / num_sqrt(len);
-		return (vec3){ ax * len, ay * len, az * len };
+		return vec3_new(ax * len, ay * len, az * len);
 	}
 	return a;
 }
@@ -370,11 +452,11 @@ static inline vec3 vec3_orthogonal(vec3 a, vec3 b){
 }
 
 static inline vec3 vec3_scale(vec3 a, float s){
-	return (vec3){ a.v[0] * s, a.v[1] * s, a.v[2] * s };
+	return vec3_new(a.v[0] * s, a.v[1] * s, a.v[2] * s);
 }
 
 static inline vec3 vec3_sub(vec3 a, vec3 b){
-	return (vec3){ a.v[0] - b.v[0], a.v[1] - b.v[1], a.v[2] - b.v[2] };
+	return vec3_new(a.v[0] - b.v[0], a.v[1] - b.v[1], a.v[2] - b.v[2]);
 }
 
 //
@@ -382,17 +464,17 @@ static inline vec3 vec3_sub(vec3 a, vec3 b){
 //
 
 static inline vec4 vec4_add(vec4 a, vec4 b){
-	return (vec4){ a.v[0] + b.v[0], a.v[1] + b.v[1], a.v[2] + b.v[2], a.v[3] + b.v[3] };
+	return vec4_new(a.v[0] + b.v[0], a.v[1] + b.v[1], a.v[2] + b.v[2], a.v[3] + b.v[3]);
 }
 
 static inline vec4 vec4_applymat4(vec4 a, mat4 *b){
 	float ax = a.v[0], ay = a.v[1], az = a.v[2], aw = a.v[3];
-	return (vec4){
+	return vec4_new(
 		b->v[0] * ax + b->v[4] * ay + b->v[ 8] * az + b->v[12] * aw,
 		b->v[1] * ax + b->v[5] * ay + b->v[ 9] * az + b->v[13] * aw,
 		b->v[2] * ax + b->v[6] * ay + b->v[10] * az + b->v[14] * aw,
 		b->v[3] * ax + b->v[7] * ay + b->v[11] * az + b->v[15] * aw
-	};
+	);
 }
 
 static inline vec4 vec4_applyquat(vec4 a, quat b){
@@ -404,21 +486,21 @@ static inline vec4 vec4_applyquat(vec4 a, quat b){
 		iy =  bw * ay + bz * ax - bx * az,
 		iz =  bw * az + bx * ay - by * ax,
 		iw = -bx * ax - by * ay - bz * az;
-	return (vec4){
+	return vec4_new(
 		ix * bw + iw * -bx + iy * -bz - iz * -by,
 		iy * bw + iw * -by + iz * -bx - ix * -bz,
 		iz * bw + iw * -bz + ix * -by - iy * -bx,
 		aw
-	};
+	);
 }
 
 static inline vec4 vec4_clamp(vec4 a, vec4 min, vec4 max){
-	return (vec4){
+	return vec4_new(
 		num_clamp(a.v[0], min.v[0], max.v[0]),
 		num_clamp(a.v[1], min.v[1], max.v[1]),
 		num_clamp(a.v[2], min.v[2], max.v[2]),
 		num_clamp(a.v[3], min.v[3], max.v[3])
-	};
+	);
 }
 
 static inline float vec4_len2(vec4 a);
@@ -432,7 +514,7 @@ static inline float vec4_dist2(vec4 a, vec4 b){
 }
 
 static inline vec4 vec4_div(vec4 a, vec4 b){
-	return (vec4){ a.v[0] / b.v[0], a.v[1] / b.v[1], a.v[2] / b.v[2], a.v[3] / b.v[3] };
+	return vec4_new(a.v[0] / b.v[0], a.v[1] / b.v[1], a.v[2] / b.v[2], a.v[3] / b.v[3]);
 }
 
 static inline float vec4_dot(vec4 a, vec4 b){
@@ -440,7 +522,7 @@ static inline float vec4_dot(vec4 a, vec4 b){
 }
 
 static inline vec4 vec4_inverse(vec4 a){
-	return (vec4){ 1.0f / a.v[0], 1.0f / a.v[1], 1.0f / a.v[2], 1.0f / a.v[3] };
+	return vec4_new(1.0f / a.v[0], 1.0f / a.v[1], 1.0f / a.v[2], 1.0f / a.v[3]);
 }
 
 static inline float vec4_len(vec4 a){
@@ -453,38 +535,38 @@ static inline float vec4_len2(vec4 a){
 }
 
 static inline vec4 vec4_lerp(vec4 a, vec4 b, float t){
-	return (vec4){
+	return vec4_new(
 		num_lerp(a.v[0], b.v[0], t),
 		num_lerp(a.v[1], b.v[1], t),
 		num_lerp(a.v[2], b.v[2], t),
 		num_lerp(a.v[3], b.v[3], t)
-	};
+	);
 }
 
 static inline vec4 vec4_max(vec4 a, vec4 b){
-	return (vec4){
+	return vec4_new(
 		num_max(a.v[0], b.v[0]),
 		num_max(a.v[1], b.v[1]),
 		num_max(a.v[2], b.v[2]),
 		num_max(a.v[3], b.v[3])
-	};
+	);
 }
 
 static inline vec4 vec4_min(vec4 a, vec4 b){
-	return (vec4){
+	return vec4_new(
 		num_min(a.v[0], b.v[0]),
 		num_min(a.v[1], b.v[1]),
 		num_min(a.v[2], b.v[2]),
 		num_min(a.v[3], b.v[3])
-	};
+	);
 }
 
 static inline vec4 vec4_mul(vec4 a, vec4 b){
-	return (vec4){ a.v[0] * b.v[0], a.v[1] * b.v[1], a.v[2] * b.v[2], a.v[3] * b.v[3] };
+	return vec4_new(a.v[0] * b.v[0], a.v[1] * b.v[1], a.v[2] * b.v[2], a.v[3] * b.v[3]);
 }
 
 static inline vec4 vec4_neg(vec4 a){
-	return (vec4){ -a.v[0], -a.v[1], -a.v[2], -a.v[3] };
+	return vec4_new(-a.v[0], -a.v[1], -a.v[2], -a.v[3]);
 }
 
 static inline vec4 vec4_normal(vec4 a){
@@ -492,17 +574,17 @@ static inline vec4 vec4_normal(vec4 a){
 	float len = ax * ax + ay * ay + az * az + aw * aw;
 	if (len > 0.0f){
 		len = 1.0f / num_sqrt(len);
-		return (vec4){ ax * len, ay * len, az * len, aw * len };
+		return vec4_new(ax * len, ay * len, az * len, aw * len);
 	}
 	return a;
 }
 
 static inline vec4 vec4_scale(vec4 a, float s){
-	return (vec4){ a.v[0] * s, a.v[1] * s, a.v[2] * s, a.v[3] * s };
+	return vec4_new(a.v[0] * s, a.v[1] * s, a.v[2] * s, a.v[3] * s);
 }
 
 static inline vec4 vec4_sub(vec4 a, vec4 b){
-	return (vec4){ a.v[0] - b.v[0], a.v[1] - b.v[1], a.v[2] - b.v[2], a.v[3] - b.v[3] };
+	return vec4_new(a.v[0] - b.v[0], a.v[1] - b.v[1], a.v[2] - b.v[2], a.v[3] - b.v[3]);
 }
 
 //
@@ -536,66 +618,66 @@ static inline float quat_dot(quat a, quat b){
 
 static inline quat quat_euler_xyz(vec3 rot){
 	NVQM_QUAT_EULER_ROT
-	return (quat){
+	return quat_new(
 		sx * cy * cz + cx * sy * sz,
 		cx * sy * cz - sx * cy * sz,
 		cx * cy * sz + sx * sy * cz,
 		cx * cy * cz - sx * sy * sz
-	};
+	);
 }
 
 static inline quat quat_euler_xzy(vec3 rot){
 	NVQM_QUAT_EULER_ROT
-	return (quat){
+	return quat_new(
 		sx * cy * cz - cx * sy * sz,
 		cx * sy * cz - sx * cy * sz,
 		cx * cy * sz + sx * sy * cz,
 		cx * cy * cz + sx * sy * sz
-	};
+	);
 }
 
 static inline quat quat_euler_yxz(vec3 rot){
 	NVQM_QUAT_EULER_ROT
-	return (quat){
+	return quat_new(
 		sx * cy * cz + cx * sy * sz,
 		cx * sy * cz - sx * cy * sz,
 		cx * cy * sz - sx * sy * cz,
 		cx * cy * cz + sx * sy * sz
-	};
+	);
 }
 
 static inline quat quat_euler_yzx(vec3 rot){
 	NVQM_QUAT_EULER_ROT
-	return (quat){
+	return quat_new(
 		sx * cy * cz + cx * sy * sz,
 		cx * sy * cz + sx * cy * sz,
 		cx * cy * sz - sx * sy * cz,
 		cx * cy * cz - sx * sy * sz
-	};
+	);
 }
 
 static inline quat quat_euler_zxy(vec3 rot){
 	NVQM_QUAT_EULER_ROT
-	return (quat){
+	return quat_new(
 		sx * cy * cz - cx * sy * sz,
 		cx * sy * cz + sx * cy * sz,
 		cx * cy * sz + sx * sy * cz,
 		cx * cy * cz - sx * sy * sz
-	};
+	);
 }
 
 static inline quat quat_euler_zyx(vec3 rot){
 	NVQM_QUAT_EULER_ROT
-	return (quat){
+	return quat_new(
 		sx * cy * cz - cx * sy * sz,
 		cx * sy * cz + sx * cy * sz,
 		cx * cy * sz - sx * sy * cz,
 		cx * cy * cz + sx * sy * sz
-	};
+	);
 }
 
 static inline quat quat_identity(){
-	return (quat){ 0.0f, 0.0f, 0.0f, 1.0f };
+	return quat_new(0.0f, 0.0f, 0.0f, 1.0f);
 }
 
 static inline quat quat_invert(quat a){
@@ -604,39 +686,39 @@ static inline quat quat_invert(quat a){
 	float invDot = 0;
 	if (dot != 0.0f)
 		invDot = 1.0f / dot;
-	return (quat){
+	return quat_new(
 		-ax * invDot,
 		-ay * invDot,
 		-az * invDot,
 		 aw * invDot
-	};
+	);
 }
 
 static inline quat quat_lerp(quat a, quat b, float t){
-	return (quat){
+	return quat_new(
 		num_lerp(a.v[0], b.v[0], t),
 		num_lerp(a.v[1], b.v[1], t),
 		num_lerp(a.v[2], b.v[2], t),
 		num_lerp(a.v[3], b.v[3], t)
-	};
+	);
 }
 
 static inline quat quat_mul(quat a, quat b){
 	float
 		ax = a.v[0], ay = a.v[1], az = a.v[2], aw = a.v[3],
 		bx = b.v[0], by = b.v[1], bz = b.v[2], bw = b.v[3];
-	return (quat){
+	return quat_new(
 		ax * bw + aw * bx + ay * bz - az * by,
 		ay * bw + aw * by + az * bx - ax * bz,
 		az * bw + aw * bz + ax * by - ay * bx,
 		aw * bw - ax * bx - ay * by - az * bz
-	};
+	);
 }
 
 static inline quat quat_naxisang(vec3 axis, float ang){ // axis is normalized
 	ang *= 0.5f;
 	float s = num_sin(ang);
-	return (quat){ axis.v[0] * s, axis.v[1] * s, axis.v[2] * s, num_cos(ang) };
+	return quat_new(axis.v[0] * s, axis.v[1] * s, axis.v[2] * s, num_cos(ang));
 }
 
 static inline quat quat_normal(quat a);
@@ -645,17 +727,17 @@ static inline quat quat_nbetween(vec3 from, vec3 to){ // from/to are normalized
 	vec3 cross;
 	if (r < 0.000001f){
 		if (num_abs(from.v[0]) > num_abs(from.v[2]))
-			cross = (vec3){ -from.v[1], from.v[0], 0.0f };
+			cross = vec3_new(-from.v[1], from.v[0], 0.0f);
 		else
-			cross = (vec3){ 0.0f, -from.v[2], from.v[1] };
+			cross = vec3_new(0.0f, -from.v[2], from.v[1]);
 	}
 	else
 		cross = vec3_cross(from, to);
-	return quat_normal((quat){ cross.v[0], cross.v[1], cross.v[2], r });
+	return quat_normal(quat_new(cross.v[0], cross.v[1], cross.v[2], r));
 }
 
 static inline quat quat_neg(quat a){
-	return (quat){ -a.v[0], -a.v[1], -a.v[2], -a.v[3] };
+	return quat_new(-a.v[0], -a.v[1], -a.v[2], -a.v[3]);
 }
 
 static inline quat quat_nlerp(quat a, quat b, float t){
@@ -667,7 +749,7 @@ static inline quat quat_normal(quat a){
 	float len = ax * ax + ay * ay + az * az + aw * aw;
 	if (len > 0.0f){
 		len = 1.0f / num_sqrt(len);
-		return (quat){ ax * len, ay * len, az * len, aw * len };
+		return quat_new(ax * len, ay * len, az * len, aw * len);
 	}
 	return a;
 }
@@ -694,12 +776,12 @@ static inline quat quat_slerp(quat a, quat b, float t){
 		scale0 = 1.0f - t;
 		scale1 = t;
 	}
-	return (quat){
+	return quat_new(
 		scale0 * ax + scale1 * bx,
 		scale0 * ay + scale1 * by,
 		scale0 * az + scale1 * bz,
 		scale0 * aw + scale1 * bw
-	};
+	);
 }
 
 //
@@ -707,15 +789,15 @@ static inline quat quat_slerp(quat a, quat b, float t){
 //
 
 static inline mat2 mat2_add(mat2 a, mat2 b){
-	return (mat2){ a.v[0] + b.v[0], a.v[1] + b.v[1], a.v[2] + b.v[2], a.v[3] + b.v[3] };
+	return mat2_new(a.v[0] + b.v[0], a.v[1] + b.v[1], a.v[2] + b.v[2], a.v[3] + b.v[3]);
 }
 
 static inline mat2 mat2_adjoint(mat2 a){
-	return (mat2){ a.v[3], -a.v[1], -a.v[2], a.v[0] };
+	return mat2_new(a.v[3], -a.v[1], -a.v[2], a.v[0]);
 }
 
 static inline mat2 mat2_compmul(mat2 a, mat2 b){
-	return (mat2){ a.v[0] * b.v[0], a.v[1] * b.v[1], a.v[2] * b.v[2], a.v[3] * b.v[3] };
+	return mat2_new(a.v[0] * b.v[0], a.v[1] * b.v[1], a.v[2] * b.v[2], a.v[3] * b.v[3]);
 }
 
 static inline float mat2_det(mat2 a){
@@ -723,52 +805,52 @@ static inline float mat2_det(mat2 a){
 }
 
 static inline mat2 mat2_identity(){
-	return (mat2){ 1.0f, 0.0f, 0.0f, 1.0f };
+	return mat2_new(1.0f, 0.0f, 0.0f, 1.0f);
 }
 
 static inline mat2 mat2_invert(mat2 a){
 	float a0 = a.v[0], a1 = a.v[1], a2 = a.v[2], a3 = a.v[3];
 	float det = a0 * a3 - a2 * a1;
 	if (det == 0.0f)
-		return (mat2){ 0.0f, 0.0f, 0.0f, 0.0f };
+		return mat2_new(0.0f, 0.0f, 0.0f, 0.0f);
 	det = 1.0f / det;
-	return (mat2){ a3 * det, -a1 * det, -a2 * det, a0 * det };
+	return mat2_new(a3 * det, -a1 * det, -a2 * det, a0 * det);
 }
 
 static inline mat2 mat2_mul(mat2 a, mat2 b){
 	float
 		a0 = a.v[0], a1 = a.v[1], a2 = a.v[2], a3 = a.v[3],
 		b0 = b.v[0], b1 = b.v[1], b2 = b.v[2], b3 = b.v[3];
-	return (mat2){ a0 * b0 + a2 * b1, a1 * b0 + a3 * b1, a0 * b2 + a2 * b3, a1 * b2 + a3 * b3 };
+	return mat2_new(a0 * b0 + a2 * b1, a1 * b0 + a3 * b1, a0 * b2 + a2 * b3, a1 * b2 + a3 * b3);
 }
 
 static inline mat2 mat2_rotate(mat2 a, float ang){
 	float a0 = a.v[0], a1 = a.v[1], a2 = a.v[2], a3 = a.v[3], s = num_sin(ang), c = num_cos(ang);
-	return (mat2){ a0 * c + a2 * s, a1 * c + a3 * s, a0 * -s + a2 * c, a1 * -s + a3 * c };
+	return mat2_new(a0 * c + a2 * s, a1 * c + a3 * s, a0 * -s + a2 * c, a1 * -s + a3 * c);
 }
 
 static inline mat2 mat2_rotation(float ang){
 	float s = num_sin(ang), c = num_cos(ang);
-	return (mat2){ c, s, -s, c };
+	return mat2_new(c, s, -s, c);
 }
 
 static inline mat2 mat2_scale(mat2 a, vec2 b){
 	float
 		a0 = a.v[0], a1 = a.v[1], a2 = a.v[2], a3 = a.v[3],
 		b0 = b.v[0], b1 = b.v[1];
-	return (mat2){ a0 * b0, a1 * b0, a2 * b1, a3 * b1 };
+	return mat2_new(a0 * b0, a1 * b0, a2 * b1, a3 * b1);
 }
 
 static inline mat2 mat2_scaling(vec2 a){
-	return (mat2){ a.v[0], 0.0f, 0.0f, a.v[1] };
+	return mat2_new(a.v[0], 0.0f, 0.0f, a.v[1]);
 }
 
 static inline mat2 mat2_sub(mat2 a, mat2 b){
-	return (mat2){ a.v[0] - b.v[0], a.v[1] - b.v[1], a.v[2] - b.v[2], a.v[3] - b.v[3] };
+	return mat2_new(a.v[0] - b.v[0], a.v[1] - b.v[1], a.v[2] - b.v[2], a.v[3] - b.v[3]);
 }
 
 static inline mat2 mat2_transpose(mat2 a){
-	return (mat2){ a.v[0], a.v[2], a.v[1], a.v[3] };
+	return mat2_new(a.v[0], a.v[2], a.v[1], a.v[3]);
 }
 
 //
@@ -776,19 +858,19 @@ static inline mat2 mat2_transpose(mat2 a){
 //
 
 static inline mat3x2 mat3x2_add(mat3x2 a, mat3x2 b){
-	return (mat3x2){
+	return mat3x2_new(
 		a.v[0] + b.v[0], a.v[1] + b.v[1],
 		a.v[2] + b.v[2], a.v[3] + b.v[3],
 		a.v[4] + b.v[4], a.v[5] + b.v[5]
-	};
+	);
 }
 
 static inline mat3x2 mat3x2_compmul(mat3x2 a, mat3x2 b){
-	return (mat3x2){
+	return mat3x2_new(
 		a.v[0] * b.v[0], a.v[1] * b.v[1],
 		a.v[2] * b.v[2], a.v[3] * b.v[3],
 		a.v[4] * b.v[4], a.v[5] * b.v[5]
-	};
+	);
 }
 
 static inline float mat3x2_det(mat3x2 a){
@@ -796,7 +878,7 @@ static inline float mat3x2_det(mat3x2 a){
 }
 
 static inline mat3x2 mat3x2_identity(){
-	return (mat3x2){ 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f };
+	return mat3x2_new(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f);
 }
 
 static inline mat3x2 mat3x2_invert(mat3x2 a){
@@ -806,14 +888,14 @@ static inline mat3x2 mat3x2_invert(mat3x2 a){
 		a20 = a.v[4], a21 = a.v[5];
 	float det = a00 * a11 - a01 * a10;
 	if (det == 0.0f)
-		return (mat3x2){ 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+		return mat3x2_new(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
 	det = 1.0f / det;
-	return (mat3x2){
+	return mat3x2_new(
 		 a11 * det, -a01 * det,
 		-a10 * det,  a00 * det,
 		( a21 * a10 - a11 * a20) * det,
 		(-a21 * a00 + a01 * a20) * det
-	};
+	);
 }
 
 static inline mat3x2 mat3x2_mul(mat3x2 a, mat3x2 b){
@@ -824,11 +906,11 @@ static inline mat3x2 mat3x2_mul(mat3x2 a, mat3x2 b){
 		b00 = b.v[0], b01 = b.v[1],
 		b10 = b.v[2], b11 = b.v[3],
 		b20 = b.v[4], b21 = b.v[5];
-	return (mat3x2){
+	return mat3x2_new(
 		b00 * a00 + b01 * a10      , b00 * a01 + b01 * a11,
 		b10 * a00 + b11 * a10      , b10 * a01 + b11 * a11,
 		b20 * a00 + b21 * a10 + a20, b20 * a01 + b21 * a11 + a21
-	};
+	);
 }
 
 static inline mat3x2 mat3x2_rotate(mat3x2 a, float ang){
@@ -836,37 +918,37 @@ static inline mat3x2 mat3x2_rotate(mat3x2 a, float ang){
 		a00 = a.v[0], a01 = a.v[1],
 		a10 = a.v[2], a11 = a.v[3],
 		s = num_sin(ang), c = num_cos(ang);
-	return (mat3x2){
+	return mat3x2_new(
 		c * a00 + s * a10, c * a01 + s * a11,
 		c * a10 - s * a00, c * a11 - s * a01,
 		a.v[4], a.v[5]
-	};
+	);
 }
 
 static inline mat3x2 mat3x2_rotation(float ang){
 	float s = num_sin(ang), c = num_cos(ang);
-	return (mat3x2){ c, s, -s, c, 0.0f, 0.0f };
+	return mat3x2_new(c, s, -s, c, 0.0f, 0.0f);
 }
 
 static inline mat3x2 mat3x2_scale(mat3x2 a, vec2 b){
 	float bx = b.v[0], by = b.v[1];
-	return (mat3x2){
+	return mat3x2_new(
 		bx * a.v[0], bx * a.v[1],
 		by * a.v[2], by * a.v[3],
-		a.v[4], a.v[5],
-	};
+		a.v[4], a.v[5]
+	);
 }
 
 static inline mat3x2 mat3x2_scaling(vec2 a){
-	return (mat3x2){ a.v[0], 0.0f, 0.0f, a.v[1], 0.0f, 0.0f };
+	return mat3x2_new(a.v[0], 0.0f, 0.0f, a.v[1], 0.0f, 0.0f);
 }
 
 static inline mat3x2 mat3x2_sub(mat3x2 a, mat3x2 b){
-	return (mat3x2){
+	return mat3x2_new(
 		a.v[0] - b.v[0], a.v[1] - b.v[1],
 		a.v[2] - b.v[2], a.v[3] - b.v[3],
 		a.v[4] - b.v[4], a.v[5] - b.v[5]
-	};
+	);
 }
 
 static inline mat3x2 mat3x2_translate(mat3x2 a, vec2 b){
@@ -874,16 +956,16 @@ static inline mat3x2 mat3x2_translate(mat3x2 a, vec2 b){
 		a00 = a.v[0], a01 = a.v[1],
 		a10 = a.v[2], a11 = a.v[3],
 		bx = b.v[0], by = b.v[1];
-	return (mat3x2){
+	return mat3x2_new(
 		a00, a01,
 		a10, a11,
 		bx * a00 + by * a10 + a.v[4],
 		bx * a01 + by * a11 + a.v[5]
-	};
+	);
 }
 
 static inline mat3x2 mat3x2_translation(vec2 a){
-	return (mat3x2){ 1.0f, 0.0f, 0.0f, 1.0f, a.v[0], a.v[1] };
+	return mat3x2_new(1.0f, 0.0f, 0.0f, 1.0f, a.v[0], a.v[1]);
 }
 
 //
@@ -958,6 +1040,88 @@ typedef struct { xint v[ 4]; } xmat2;
 typedef struct { xint v[ 6]; } xmat3x2;
 typedef struct { xint v[ 9]; } xmat3;
 typedef struct { xint v[16]; } xmat4;
+
+static inline xvec2 xvec2_new(xint x, xint y){
+	xvec2 res;
+	res.v[0] = x;
+	res.v[1] = y;
+	return res;
+}
+static inline xvec3 xvec3_new(xint x, xint y, xint z){
+	xvec3 res;
+	res.v[0] = x;
+	res.v[1] = y;
+	res.v[2] = z;
+	return res;
+}
+static inline xvec4 xvec4_new(xint x, xint y, xint z, xint w){
+	xvec4 res;
+	res.v[0] = x;
+	res.v[1] = y;
+	res.v[2] = z;
+	res.v[3] = w;
+	return res;
+}
+static inline xquat xquat_new(xint s, xint i, xint j, xint k){
+	xquat res;
+	res.v[0] = s;
+	res.v[1] = i;
+	res.v[2] = j;
+	res.v[3] = k;
+	return res;
+}
+
+static inline xmat2 xmat2_new(xint v00, xint v01, xint v10, xint v11){
+	xmat2 res;
+	res.v[0] = v00;
+	res.v[1] = v01;
+	res.v[2] = v10;
+	res.v[3] = v11;
+	return res;
+}
+static inline xmat3x2 xmat3x2_new(xint v00, xint v01, xint v10, xint v11, xint v20, xint v21){
+	xmat3x2 res;
+	res.v[0] = v00;
+	res.v[1] = v01;
+	res.v[2] = v10;
+	res.v[3] = v11;
+	res.v[4] = v20;
+	res.v[5] = v21;
+	return res;
+}
+static inline xmat3 xmat3_new(xint v00, xint v01, xint v02, xint v10, xint v11, xint v12, xint v20, xint v21, xint v22){
+	xmat3 res;
+	res.v[0] = v00;
+	res.v[1] = v01;
+	res.v[2] = v02;
+	res.v[3] = v10;
+	res.v[4] = v11;
+	res.v[5] = v12;
+	res.v[6] = v20;
+	res.v[7] = v21;
+	res.v[8] = v22;
+	return res;
+}
+static inline xmat4 xmat4_new(xint v00, xint v01, xint v02, xint v03, xint v10, xint v11, xint v12, xint v13, xint v20, xint v21, xint v22, xint v23, xint v30, xint v31, xint v32, xint v33){
+	xmat4 res;
+	res.v[0] = v00;
+	res.v[1] = v01;
+	res.v[2] = v02;
+	res.v[3] = v03;
+	res.v[4] = v10;
+	res.v[5] = v11;
+	res.v[6] = v12;
+	res.v[7] = v13;
+	res.v[8] = v20;
+	res.v[9] = v21;
+	res.v[10] = v22;
+	res.v[11] = v23;
+	res.v[12] = v30;
+	res.v[13] = v31;
+	res.v[14] = v32;
+	res.v[15] = v33;
+	return res;
+}
 
 #define XINT1    65536 /* the value 1 */
 #define XINT(v)  ((xint)((v) * XINT1))
@@ -1110,55 +1274,55 @@ static inline xint xint_tan(xang a){
 
 #ifndef NVQM_SKIP_FLOATING_POINT
 static inline vec2 xvec2_tovec2(xvec2 a){
-	return (vec2){ xint_tofloat(a.v[0]), xint_tofloat(a.v[1]) };
+	return vec2_new(xint_tofloat(a.v[0]), xint_tofloat(a.v[1]));
 }
 
 static inline xvec2 xvec2_fromvec2(vec2 a){
-	return (xvec2){ xint_fromfloat(a.v[0]), xint_fromfloat(a.v[1]) };
+	return xvec2_new(xint_fromfloat(a.v[0]), xint_fromfloat(a.v[1]));
 }
 #endif
 
 static inline xvec2 xvec2_add(xvec2 a, xvec2 b){
-	return (xvec2){ xint_add(a.v[0], b.v[0]), xint_add(a.v[1], b.v[1]) };
+	return xvec2_new(xint_add(a.v[0], b.v[0]), xint_add(a.v[1], b.v[1]));
 }
 
 static inline xvec2 xvec2_applymat2(xvec2 a, xmat2 b){
 	xint ax = a.v[0], ay = a.v[1];
-	return (xvec2){
+	return xvec2_new(
 		xint_add(xint_mul(b.v[0], ax), xint_mul(b.v[2], ay)),
 		xint_add(xint_mul(b.v[1], ax), xint_mul(b.v[3], ay))
-	};
+	);
 }
 
 static inline xvec2 xvec2_applymat3x2(xvec2 a, xmat3x2 b){
 	xint ax = a.v[0], ay = a.v[1];
-	return (xvec2){
+	return xvec2_new(
 		xint_add(xint_add(xint_mul(b.v[0], ax), xint_mul(b.v[2], ay)), b.v[4]),
 		xint_add(xint_add(xint_mul(b.v[1], ax), xint_mul(b.v[3], ay)), b.v[5])
-	};
+	);
 }
 
 static inline xvec2 xvec2_applymat3(xvec2 a, xmat3 *b){
 	xint ax = a.v[0], ay = a.v[1];
-	return (xvec2){
+	return xvec2_new(
 		xint_add(xint_add(xint_mul(b->v[0], ax), xint_mul(b->v[3], ay)), b->v[6]),
 		xint_add(xint_add(xint_mul(b->v[1], ax), xint_mul(b->v[4], ay)), b->v[7])
-	};
+	);
 }
 
 static inline xvec2 xvec2_applymat4(xvec2 a, xmat4 *b){
 	xint ax = a.v[0], ay = a.v[1];
-	return (xvec2){
+	return xvec2_new(
 		xint_add(xint_add(xint_mul(b->v[0], ax), xint_mul(b->v[4], ay)), b->v[12]),
 		xint_add(xint_add(xint_mul(b->v[1], ax), xint_mul(b->v[5], ay)), b->v[13])
-	};
+	);
 }
 
 static inline xvec2 xvec2_clamp(xvec2 a, xvec2 min, xvec2 max){
-	return (xvec2){
+	return xvec2_new(
 		xint_clamp(a.v[0], min.v[0], max.v[0]),
 		xint_clamp(a.v[1], min.v[1], max.v[1])
-	};
+	);
 }
 
 static inline xint xvec2_cross(xvec2 a, xvec2 b){
@@ -1176,7 +1340,7 @@ static inline xint xvec2_dist2(xvec2 a, xvec2 b){
 }
 
 static inline xvec2 xvec2_div(xvec2 a, xvec2 b){
-	return (xvec2){ xint_div(a.v[0], b.v[0]), xint_div(a.v[1], b.v[1]) };
+	return xvec2_new(xint_div(a.v[0], b.v[0]), xint_div(a.v[1], b.v[1]));
 }
 
 static inline xint xvec2_dot(xvec2 a, xvec2 b){
@@ -1184,7 +1348,7 @@ static inline xint xvec2_dot(xvec2 a, xvec2 b){
 }
 
 static inline xvec2 xvec2_inverse(xvec2 a){
-	return (xvec2){ xint_div(XINT1, a.v[0]), xint_div(XINT1, a.v[1]) };
+	return xvec2_new(xint_div(XINT1, a.v[0]), xint_div(XINT1, a.v[1]));
 }
 
 static inline xint xvec2_len(xvec2 a){
@@ -1197,23 +1361,23 @@ static inline xint xvec2_len2(xvec2 a){
 }
 
 static inline xvec2 xvec2_lerp(xvec2 a, xvec2 b, xint t){
-	return (xvec2){ xint_lerp(a.v[0], b.v[0], t), xint_lerp(a.v[1], b.v[1], t) };
+	return xvec2_new(xint_lerp(a.v[0], b.v[0], t), xint_lerp(a.v[1], b.v[1], t));
 }
 
 static inline xvec2 xvec2_max(xvec2 a, xvec2 b){
-	return (xvec2){ xint_max(a.v[0], b.v[0]), xint_max(a.v[1], b.v[1]) };
+	return xvec2_new(xint_max(a.v[0], b.v[0]), xint_max(a.v[1], b.v[1]));
 }
 
 static inline xvec2 xvec2_min(xvec2 a, xvec2 b){
-	return (xvec2){ xint_min(a.v[0], b.v[0]), xint_min(a.v[1], b.v[1]) };
+	return xvec2_new(xint_min(a.v[0], b.v[0]), xint_min(a.v[1], b.v[1]));
 }
 
 static inline xvec2 xvec2_mul(xvec2 a, xvec2 b){
-	return (xvec2){ xint_mul(a.v[0], b.v[0]), xint_mul(a.v[1], b.v[1]) };
+	return xvec2_new(xint_mul(a.v[0], b.v[0]), xint_mul(a.v[1], b.v[1]));
 }
 
 static inline xvec2 xvec2_neg(xvec2 a){
-	return (xvec2){ -a.v[0], -a.v[1] };
+	return xvec2_new(-a.v[0], -a.v[1]);
 }
 
 static inline xvec2 xvec2_normal(xvec2 a){
@@ -1221,17 +1385,17 @@ static inline xvec2 xvec2_normal(xvec2 a){
 		len = xint_add(xint_mul(ax, ax), xint_mul(ay, ay));
 	if (len > 0){
 		len = xint_div(XINT1, xint_sqrt(len));
-		return (xvec2){ xint_mul(ax, len), xint_mul(ay, len) };
+		return xvec2_new(xint_mul(ax, len), xint_mul(ay, len));
 	}
 	return a;
 }
 
 static inline xvec2 xvec2_scale(xvec2 a, xint s){
-	return (xvec2){ xint_mul(a.v[0], s), xint_mul(a.v[1], s) };
+	return xvec2_new(xint_mul(a.v[0], s), xint_mul(a.v[1], s));
 }
 
 static inline xvec2 xvec2_sub(xvec2 a, xvec2 b){
-	return (xvec2){ xint_sub(a.v[0], b.v[0]), xint_sub(a.v[1], b.v[1]) };
+	return xvec2_new(xint_sub(a.v[0], b.v[0]), xint_sub(a.v[1], b.v[1]));
 }
 
 //
@@ -1240,16 +1404,16 @@ static inline xvec2 xvec2_sub(xvec2 a, xvec2 b){
 
 #ifndef NVQM_SKIP_FLOATING_POINT
 static inline vec3 xvec3_tovec3(xvec3 a){
-	return (vec3){ xint_tofloat(a.v[0]), xint_tofloat(a.v[1]), xint_tofloat(a.v[2]) };
+	return vec3_new(xint_tofloat(a.v[0]), xint_tofloat(a.v[1]), xint_tofloat(a.v[2]));
 }
 
 static inline xvec3 xvec3_fromvec3(vec3 a){
-	return (xvec3){ xint_fromfloat(a.v[0]), xint_fromfloat(a.v[1]), xint_fromfloat(a.v[2]) };
+	return xvec3_new(xint_fromfloat(a.v[0]), xint_fromfloat(a.v[1]), xint_fromfloat(a.v[2]));
 }
 #endif
 
 static inline xvec3 xvec3_add(xvec3 a, xvec3 b){
-	return (xvec3){ xint_add(a.v[0], b.v[0]), xint_add(a.v[1], b.v[1]), xint_add(a.v[2], b.v[2]) };
+	return xvec3_new(xint_add(a.v[0], b.v[0]), xint_add(a.v[1], b.v[1]), xint_add(a.v[2], b.v[2]));
 }
 
 static inline xint xvec3_nangle(xvec3 a, xvec3 b);
@@ -1260,20 +1424,20 @@ static inline xint xvec3_angle(xvec3 a, xvec3 b){
 
 static inline xvec3 xvec3_applymat3x2(xvec3 a, xmat3x2 b){
 	xint ax = a.v[0], ay = a.v[1], az = a.v[2];
-	return (xvec3){
+	return xvec3_new(
 		xint_add(xint_add(xint_mul(ax, b.v[0]), xint_mul(ay, b.v[2])), xint_mul(az, b.v[4])),
 		xint_add(xint_add(xint_mul(ax, b.v[1]), xint_mul(ay, b.v[3])), xint_mul(az, b.v[5])),
 		az
-	};
+	);
 }
 
 static inline xvec3 xvec3_applymat3(xvec3 a, xmat3 *b){
 	xint ax = a.v[0], ay = a.v[1], az = a.v[2];
-	return (xvec3){
+	return xvec3_new(
 		xint_add(xint_add(xint_mul(ax, b->v[0]), xint_mul(ay, b->v[3])), xint_mul(az, b->v[6])),
 		xint_add(xint_add(xint_mul(ax, b->v[1]), xint_mul(ay, b->v[4])), xint_mul(az, b->v[7])),
 		xint_add(xint_add(xint_mul(ax, b->v[2]), xint_mul(ay, b->v[5])), xint_mul(az, b->v[8]))
-	};
+	);
 }
 
 static inline xvec3 xvec3_applymat4(xvec3 a, xmat4 *b){
@@ -1286,7 +1450,7 @@ static inline xvec3 xvec3_applymat4(xvec3 a, xmat4 *b){
 		w = XINT1;
 	else
 		w = xint_div(XINT1, w);
-	return (xvec3){
+	return xvec3_new(
 		xint_mul(w,
 			xint_add(xint_add(
 				xint_mul(b->v[ 0], ax),
@@ -1308,7 +1472,7 @@ static inline xvec3 xvec3_applymat4(xvec3 a, xmat4 *b){
 				xint_mul(b->v[10], az),
 				b->v[14]
 			)))
-	};
+	);
 }
 
 static inline xvec3 xvec3_applyquat(xvec3 a, xquat b){
@@ -1320,33 +1484,33 @@ static inline xvec3 xvec3_applyquat(xvec3 a, xquat b){
 		iy = xint_sub(xint_add(xint_mul( bw, ay), xint_mul(bz, ax)), xint_mul(bx, az)),
 		iz = xint_sub(xint_add(xint_mul( bw, az), xint_mul(bx, ay)), xint_mul(by, ax)),
 		iw = xint_sub(xint_sub(xint_mul(-bx, ax), xint_mul(by, ay)), xint_mul(bz, az));
-	return (xvec3){
+	return xvec3_new(
 		xint_sub(xint_add(xint_add(
 			xint_mul(ix, bw), xint_mul(iw, -bx)), xint_mul(iy, -bz)), xint_mul(iz, -by)),
 		xint_sub(xint_add(xint_add(
 			xint_mul(iy, bw), xint_mul(iw, -by)), xint_mul(iz, -bx)), xint_mul(ix, -bz)),
 		xint_sub(xint_add(xint_add(
 			xint_mul(iz, bw), xint_mul(iw, -bz)), xint_mul(ix, -by)), xint_mul(iy, -bx))
-	};
+	);
 }
 
 static inline xvec3 xvec3_clamp(xvec3 a, xvec3 min, xvec3 max){
-	return (xvec3){
+	return xvec3_new(
 		xint_clamp(a.v[0], min.v[0], max.v[0]),
 		xint_clamp(a.v[1], min.v[1], max.v[1]),
 		xint_clamp(a.v[2], min.v[2], max.v[2])
-	};
+	);
 }
 
 static inline xvec3 xvec3_cross(xvec3 a, xvec3 b){
 	xint
 		ax = a.v[0], ay = a.v[1], az = a.v[2],
 		bx = b.v[0], by = b.v[1], bz = b.v[2];
-	return (xvec3){
+	return xvec3_new(
 		xint_sub(xint_mul(ay, bz), xint_mul(az, by)),
 		xint_sub(xint_mul(az, bx), xint_mul(ax, bz)),
 		xint_sub(xint_mul(ax, by), xint_mul(ay, bx))
-	};
+	);
 }
 
 static inline xint xvec3_len2(xvec3 a);
@@ -1360,7 +1524,7 @@ static inline xint xvec3_dist2(xvec3 a, xvec3 b){
 }
 
 static inline xvec3 xvec3_div(xvec3 a, xvec3 b){
-	return (xvec3){ xint_div(a.v[0], b.v[0]), xint_div(a.v[1], b.v[1]), xint_div(a.v[2], b.v[2]) };
+	return xvec3_new(xint_div(a.v[0], b.v[0]), xint_div(a.v[1], b.v[1]), xint_div(a.v[2], b.v[2]));
 }
 
 static inline xint xvec3_dot(xvec3 a, xvec3 b){
@@ -1369,7 +1533,7 @@ static inline xint xvec3_dot(xvec3 a, xvec3 b){
 }
 
 static inline xvec3 xvec3_inverse(xvec3 a){
-	return (xvec3){ xint_div(XINT1, a.v[0]), xint_div(XINT1, a.v[1]), xint_div(XINT1, a.v[2]) };
+	return xvec3_new(xint_div(XINT1, a.v[0]), xint_div(XINT1, a.v[1]), xint_div(XINT1, a.v[2]));
 }
 
 static inline xint xvec3_len(xvec3 a){
@@ -1382,23 +1546,23 @@ static inline xint xvec3_len2(xvec3 a){
 }
 
 static inline xvec3 xvec3_lerp(xvec3 a, xvec3 b, xint t){
-	return (xvec3){
+	return xvec3_new(
 		xint_lerp(a.v[0], b.v[0], t),
 		xint_lerp(a.v[1], b.v[1], t),
 		xint_lerp(a.v[2], b.v[2], t)
-	};
+	);
 }
 
 static inline xvec3 xvec3_max(xvec3 a, xvec3 b){
-	return (xvec3){ xint_max(a.v[0], b.v[0]), xint_max(a.v[1], b.v[1]), xint_max(a.v[2], b.v[2]) };
+	return xvec3_new(xint_max(a.v[0], b.v[0]), xint_max(a.v[1], b.v[1]), xint_max(a.v[2], b.v[2]));
 }
 
 static inline xvec3 xvec3_min(xvec3 a, xvec3 b){
-	return (xvec3){ xint_min(a.v[0], b.v[0]), xint_min(a.v[1], b.v[1]), xint_min(a.v[2], b.v[2]) };
+	return xvec3_new(xint_min(a.v[0], b.v[0]), xint_min(a.v[1], b.v[1]), xint_min(a.v[2], b.v[2]));
 }
 
 static inline xvec3 xvec3_mul(xvec3 a, xvec3 b){
-	return (xvec3){ xint_mul(a.v[0], b.v[0]), xint_mul(a.v[1], b.v[1]), xint_mul(a.v[2], b.v[2]) };
+	return xvec3_new(xint_mul(a.v[0], b.v[0]), xint_mul(a.v[1], b.v[1]), xint_mul(a.v[2], b.v[2]));
 }
 
 static inline xint xvec3_nangle(xvec3 a, xvec3 b){ // a and b are normalized
@@ -1406,7 +1570,7 @@ static inline xint xvec3_nangle(xvec3 a, xvec3 b){ // a and b are normalized
 }
 
 static inline xvec3 xvec3_neg(xvec3 a){
-	return (xvec3){ -a.v[0], -a.v[1], -a.v[2] };
+	return xvec3_new(-a.v[0], -a.v[1], -a.v[2]);
 }
 
 static inline xvec3 xvec3_normal(xvec3 a){
@@ -1416,7 +1580,7 @@ static inline xvec3 xvec3_normal(xvec3 a){
 		len = xint_sqrt(len);
 		if (len > 0){
 			len = xint_div(XINT1, len);
-			return (xvec3){ xint_mul(ax, len), xint_mul(ay, len), xint_mul(az, len) };
+			return xvec3_new(xint_mul(ax, len), xint_mul(ay, len), xint_mul(az, len));
 		}
 	}
 	return a;
@@ -1428,11 +1592,11 @@ static inline xvec3 xvec3_orthogonal(xvec3 a, xvec3 b){
 }
 
 static inline xvec3 xvec3_scale(xvec3 a, xint s){
-	return (xvec3){ xint_mul(a.v[0], s), xint_mul(a.v[1], s), xint_mul(a.v[2], s) };
+	return xvec3_new(xint_mul(a.v[0], s), xint_mul(a.v[1], s), xint_mul(a.v[2], s));
 }
 
 static inline xvec3 xvec3_sub(xvec3 a, xvec3 b){
-	return (xvec3){ xint_sub(a.v[0], b.v[0]), xint_sub(a.v[1], b.v[1]), xint_sub(a.v[2], b.v[2]) };
+	return xvec3_new(xint_sub(a.v[0], b.v[0]), xint_sub(a.v[1], b.v[1]), xint_sub(a.v[2], b.v[2]));
 }
 
 //
@@ -1441,36 +1605,36 @@ static inline xvec3 xvec3_sub(xvec3 a, xvec3 b){
 
 #ifndef NVQM_SKIP_FLOATING_POINT
 static inline vec4 xvec4_tovec4(xvec4 a){
-	return (vec4){
+	return vec4_new(
 		xint_tofloat(a.v[0]),
 		xint_tofloat(a.v[1]),
 		xint_tofloat(a.v[2]),
 		xint_tofloat(a.v[3])
-	};
+	);
 }
 
 static inline xvec4 xvec4_fromvec4(vec4 a){
-	return (xvec4){
+	return xvec4_new(
 		xint_fromfloat(a.v[0]),
 		xint_fromfloat(a.v[1]),
 		xint_fromfloat(a.v[2]),
 		xint_fromfloat(a.v[3])
-	};
+	);
 }
 #endif
 
 static inline xvec4 xvec4_add(xvec4 a, xvec4 b){
-	return (xvec4){
+	return xvec4_new(
 		xint_add(a.v[0], b.v[0]),
 		xint_add(a.v[1], b.v[1]),
 		xint_add(a.v[2], b.v[2]),
 		xint_add(a.v[3], b.v[3])
-	};
+	);
 }
 
 static inline xvec4 xvec4_applymat4(xvec4 a, xmat4 *b){
 	xint ax = a.v[0], ay = a.v[1], az = a.v[2], aw = a.v[3];
-	return (xvec4){
+	return xvec4_new(
 		xint_add(xint_add(xint_add(
 			xint_mul(b->v[ 0], ax),
 			xint_mul(b->v[ 4], ay)),
@@ -1491,7 +1655,7 @@ static inline xvec4 xvec4_applymat4(xvec4 a, xmat4 *b){
 			xint_mul(b->v[ 7], ay)),
 			xint_mul(b->v[11], az)),
 			xint_mul(b->v[15], aw))
-	};
+	);
 }
 
 static inline xvec4 xvec4_applyquat(xvec4 a, xquat b){
@@ -1503,7 +1667,7 @@ static inline xvec4 xvec4_applyquat(xvec4 a, xquat b){
 		iy = xint_sub(xint_add(xint_mul( bw, ay), xint_mul(bz, ax)), xint_mul(bx, az)),
 		iz = xint_sub(xint_add(xint_mul( bw, az), xint_mul(bx, ay)), xint_mul(by, ax)),
 		iw = xint_sub(xint_sub(xint_mul(-bx, ax), xint_mul(by, ay)), xint_mul(bz, az));
-	return (xvec4){
+	return xvec4_new(
 		xint_sub(xint_add(xint_add(
 			xint_mul(ix, bw), xint_mul(iw, -bx)), xint_mul(iy, -bz)), xint_mul(iz, -by)),
 		xint_sub(xint_add(xint_add(
@@ -1511,16 +1675,16 @@ static inline xvec4 xvec4_applyquat(xvec4 a, xquat b){
 		xint_sub(xint_add(xint_add(
 			xint_mul(iz, bw), xint_mul(iw, -bz)), xint_mul(ix, -by)), xint_mul(iy, -bx)),
 		aw
-	};
+	);
 }
 
 static inline xvec4 xvec4_clamp(xvec4 a, xvec4 min, xvec4 max){
-	return (xvec4){
+	return xvec4_new(
 		xint_clamp(a.v[0], min.v[0], max.v[0]),
 		xint_clamp(a.v[1], min.v[1], max.v[1]),
 		xint_clamp(a.v[2], min.v[2], max.v[2]),
 		xint_clamp(a.v[3], min.v[3], max.v[3])
-	};
+	);
 }
 
 static inline xint xvec4_len2(xvec4 a);
@@ -1534,12 +1698,12 @@ static inline xint xvec4_dist2(xvec4 a, xvec4 b){
 }
 
 static inline xvec4 xvec4_div(xvec4 a, xvec4 b){
-	return (xvec4){
+	return xvec4_new(
 		xint_div(a.v[0], b.v[0]),
 		xint_div(a.v[1], b.v[1]),
 		xint_div(a.v[2], b.v[2]),
 		xint_div(a.v[3], b.v[3])
-	};
+	);
 }
 
 static inline xint xvec4_dot(xvec4 a, xvec4 b){
@@ -1551,12 +1715,12 @@ static inline xint xvec4_dot(xvec4 a, xvec4 b){
 }
 
 static inline xvec4 xvec4_inverse(xvec4 a){
-	return (xvec4){
+	return xvec4_new(
 		xint_div(XINT1, a.v[0]),
 		xint_div(XINT1, a.v[1]),
 		xint_div(XINT1, a.v[2]),
 		xint_div(XINT1, a.v[3])
-	};
+	);
 }
 
 static inline xint xvec4_len(xvec4 a){
@@ -1570,43 +1734,43 @@ static inline xint xvec4_len2(xvec4 a){
 }
 
 static inline xvec4 xvec4_lerp(xvec4 a, xvec4 b, xint t){
-	return (xvec4){
+	return xvec4_new(
 		xint_lerp(a.v[0], b.v[0], t),
 		xint_lerp(a.v[1], b.v[1], t),
 		xint_lerp(a.v[2], b.v[2], t),
 		xint_lerp(a.v[3], b.v[3], t)
-	};
+	);
 }
 
 static inline xvec4 xvec4_max(xvec4 a, xvec4 b){
-	return (xvec4){
+	return xvec4_new(
 		xint_max(a.v[0], b.v[0]),
 		xint_max(a.v[1], b.v[1]),
 		xint_max(a.v[2], b.v[2]),
 		xint_max(a.v[3], b.v[3])
-	};
+	);
 }
 
 static inline xvec4 xvec4_min(xvec4 a, xvec4 b){
-	return (xvec4){
+	return xvec4_new(
 		xint_min(a.v[0], b.v[0]),
 		xint_min(a.v[1], b.v[1]),
 		xint_min(a.v[2], b.v[2]),
 		xint_min(a.v[3], b.v[3])
-	};
+	);
 }
 
 static inline xvec4 xvec4_mul(xvec4 a, xvec4 b){
-	return (xvec4){
+	return xvec4_new(
 		xint_mul(a.v[0], b.v[0]),
 		xint_mul(a.v[1], b.v[1]),
 		xint_mul(a.v[2], b.v[2]),
 		xint_mul(a.v[3], b.v[3])
-	};
+	);
 }
 
 static inline xvec4 xvec4_neg(xvec4 a){
-	return (xvec4){ -a.v[0], -a.v[1], -a.v[2], -a.v[3] };
+	return xvec4_new(-a.v[0], -a.v[1], -a.v[2], -a.v[3]);
 }
 
 static inline xvec4 xvec4_normal(xvec4 a){
@@ -1617,33 +1781,33 @@ static inline xvec4 xvec4_normal(xvec4 a){
 		len = xint_sqrt(len);
 		if (len > 0){
 			len = xint_div(XINT1, len);
-			return (xvec4){
+			return xvec4_new(
 				xint_mul(ax, len),
 				xint_mul(ay, len),
 				xint_mul(az, len),
 				xint_mul(aw, len)
-			};
+			);
 		}
 	}
 	return a;
 }
 
 static inline xvec4 xvec4_scale(xvec4 a, xint s){
-	return (xvec4){
+	return xvec4_new(
 		xint_mul(a.v[0], s),
 		xint_mul(a.v[1], s),
 		xint_mul(a.v[2], s),
 		xint_mul(a.v[3], s)
-	};
+	);
 }
 
 static inline xvec4 xvec4_sub(xvec4 a, xvec4 b){
-	return (xvec4){
+	return xvec4_new(
 		xint_sub(a.v[0], b.v[0]),
 		xint_sub(a.v[1], b.v[1]),
 		xint_sub(a.v[2], b.v[2]),
 		xint_sub(a.v[3], b.v[3])
-	};
+	);
 }
 
 //
@@ -1652,21 +1816,21 @@ static inline xvec4 xvec4_sub(xvec4 a, xvec4 b){
 
 #ifndef NVQM_SKIP_FLOATING_POINT
 static inline quat xquat_toquat(xquat a){
-	return (quat){
+	return quat_new(
 		xint_tofloat(a.v[0]),
 		xint_tofloat(a.v[1]),
 		xint_tofloat(a.v[2]),
 		xint_tofloat(a.v[3])
-	};
+	);
 }
 
 static inline xquat xquat_fromquat(quat a){
-	return (xquat){
+	return xquat_new(
 		xint_fromfloat(a.v[0]),
 		xint_fromfloat(a.v[1]),
 		xint_fromfloat(a.v[2]),
 		xint_fromfloat(a.v[3])
-	};
+	);
 }
 #endif
 
@@ -1701,66 +1865,66 @@ static inline xint xquat_dot(xquat a, xquat b){
 
 static inline xquat xquat_euler_xyz(xvec3 rot){
 	NVQM_XQUAT_EULER_ROT
-	return (xquat){
+	return xquat_new(
 		xint_add(xint_mul(xint_mul(sx, cy), cz), xint_mul(xint_mul(cx, sy), sz)),
 		xint_sub(xint_mul(xint_mul(cx, sy), cz), xint_mul(xint_mul(sx, cy), sz)),
 		xint_add(xint_mul(xint_mul(cx, cy), sz), xint_mul(xint_mul(sx, sy), cz)),
 		xint_sub(xint_mul(xint_mul(cx, cy), cz), xint_mul(xint_mul(sx, sy), sz))
-	};
+	);
 }
 
 static inline xquat xquat_euler_xzy(xvec3 rot){
 	NVQM_XQUAT_EULER_ROT
-	return (xquat){
+	return xquat_new(
 		xint_sub(xint_mul(xint_mul(sx, cy), cz), xint_mul(xint_mul(cx, sy), sz)),
 		xint_sub(xint_mul(xint_mul(cx, sy), cz), xint_mul(xint_mul(sx, cy), sz)),
 		xint_add(xint_mul(xint_mul(cx, cy), sz), xint_mul(xint_mul(sx, sy), cz)),
 		xint_add(xint_mul(xint_mul(cx, cy), cz), xint_mul(xint_mul(sx, sy), sz))
-	};
+	);
 }
 
 static inline xquat xquat_euler_yxz(xvec3 rot){
 	NVQM_XQUAT_EULER_ROT
-	return (xquat){
+	return xquat_new(
 		xint_add(xint_mul(xint_mul(sx, cy), cz), xint_mul(xint_mul(cx, sy), sz)),
 		xint_sub(xint_mul(xint_mul(cx, sy), cz), xint_mul(xint_mul(sx, cy), sz)),
 		xint_sub(xint_mul(xint_mul(cx, cy), sz), xint_mul(xint_mul(sx, sy), cz)),
 		xint_add(xint_mul(xint_mul(cx, cy), cz), xint_mul(xint_mul(sx, sy), sz))
-	};
+	);
 }
 
 static inline xquat xquat_euler_yzx(xvec3 rot){
 	NVQM_XQUAT_EULER_ROT
-	return (xquat){
+	return xquat_new(
 		xint_add(xint_mul(xint_mul(sx, cy), cz), xint_mul(xint_mul(cx, sy), sz)),
 		xint_add(xint_mul(xint_mul(cx, sy), cz), xint_mul(xint_mul(sx, cy), sz)),
 		xint_sub(xint_mul(xint_mul(cx, cy), sz), xint_mul(xint_mul(sx, sy), cz)),
 		xint_sub(xint_mul(xint_mul(cx, cy), cz), xint_mul(xint_mul(sx, sy), sz))
-	};
+	);
 }
 
 static inline xquat xquat_euler_zxy(xvec3 rot){
 	NVQM_XQUAT_EULER_ROT
-	return (xquat){
+	return xquat_new(
 		xint_sub(xint_mul(xint_mul(sx, cy), cz), xint_mul(xint_mul(cx, sy), sz)),
 		xint_add(xint_mul(xint_mul(cx, sy), cz), xint_mul(xint_mul(sx, cy), sz)),
 		xint_add(xint_mul(xint_mul(cx, cy), sz), xint_mul(xint_mul(sx, sy), cz)),
 		xint_sub(xint_mul(xint_mul(cx, cy), cz), xint_mul(xint_mul(sx, sy), sz))
-	};
+	);
 }
 
 static inline xquat xquat_euler_zyx(xvec3 rot){
 	NVQM_XQUAT_EULER_ROT
-	return (xquat){
+	return xquat_new(
 		xint_sub(xint_mul(xint_mul(sx, cy), cz), xint_mul(xint_mul(cx, sy), sz)),
 		xint_add(xint_mul(xint_mul(cx, sy), cz), xint_mul(xint_mul(sx, cy), sz)),
 		xint_sub(xint_mul(xint_mul(cx, cy), sz), xint_mul(xint_mul(sx, sy), cz)),
 		xint_add(xint_mul(xint_mul(cx, cy), cz), xint_mul(xint_mul(sx, sy), sz))
-	};
+	);
 }
 
 static inline xquat xquat_identity(){
-	return (xquat){ 0, 0, 0, XINT1 };
+	return xquat_new(0, 0, 0, XINT1);
 }
 
 static inline xquat xquat_invert(xquat a){
@@ -1770,28 +1934,28 @@ static inline xquat xquat_invert(xquat a){
 	xint invDot = 0;
 	if (dot != 0)
 		invDot = xint_div(XINT1, dot);
-	return (xquat){
+	return xquat_new(
 		xint_mul(-ax, invDot),
 		xint_mul(-ay, invDot),
 		xint_mul(-az, invDot),
 		xint_mul( aw, invDot)
-	};
+	);
 }
 
 static inline xquat xquat_lerp(xquat a, xquat b, xint t){
-	return (xquat){
+	return xquat_new(
 		xint_lerp(a.v[0], b.v[0], t),
 		xint_lerp(a.v[1], b.v[1], t),
 		xint_lerp(a.v[2], b.v[2], t),
 		xint_lerp(a.v[3], b.v[3], t)
-	};
+	);
 }
 
 static inline xquat xquat_mul(xquat a, xquat b){
 	xint
 		ax = a.v[0], ay = a.v[1], az = a.v[2], aw = a.v[3],
 		bx = b.v[0], by = b.v[1], bz = b.v[2], bw = b.v[3];
-	return (xquat){
+	return xquat_new(
 		xint_sub(xint_add(xint_add(
 			xint_mul(ax, bw), xint_mul(aw, bx)), xint_mul(ay, bz)), xint_mul(az, by)),
 		xint_sub(xint_add(xint_add(
@@ -1800,14 +1964,18 @@ static inline xquat xquat_mul(xquat a, xquat b){
 			xint_mul(az, bw), xint_mul(aw, bz)), xint_mul(ax, by)), xint_mul(ay, bx)),
 		xint_sub(xint_sub(xint_sub(
 			xint_mul(aw, bw), xint_mul(ax, bx)), xint_mul(ay, by)), xint_mul(az, bz))
-	};
+	);
 }
 
 static inline xquat xquat_naxisang(xvec3 axis, xang ang){ // axis is normalized
 	ang >>= 1;
 	xint s = xint_sin(ang);
-	return (xquat){
-		xint_mul(axis.v[0], s), xint_mul(axis.v[1], s), xint_mul(axis.v[2], s), xint_cos(ang) };
+	return xquat_new(
+		xint_mul(axis.v[0], s),
+		xint_mul(axis.v[1], s),
+		xint_mul(axis.v[2], s),
+		xint_cos(ang)
+	);
 }
 
 static inline xquat xquat_normal(xquat a);
@@ -1816,17 +1984,17 @@ static inline xquat xquat_nbetween(xvec3 from, xvec3 to){ // from/to are normali
 	xvec3 cross;
 	if (r <= 0){
 		if (xint_abs(from.v[0]) > xint_abs(from.v[2]))
-			cross = (xvec3){ -from.v[1], from.v[0], 0 };
+			cross = xvec3_new(-from.v[1], from.v[0], 0);
 		else
-			cross = (xvec3){ 0, -from.v[2], from.v[1] };
+			cross = xvec3_new(0, -from.v[2], from.v[1]);
 	}
 	else
 		cross = xvec3_cross(from, to);
-	return xquat_normal((xquat){ cross.v[0], cross.v[1], cross.v[2], r });
+	return xquat_normal(xquat_new(cross.v[0], cross.v[1], cross.v[2], r));
 }
 
 static inline xquat xquat_neg(xquat a){
-	return (xquat){ -a.v[0], -a.v[1], -a.v[2], -a.v[3] };
+	return xquat_new(-a.v[0], -a.v[1], -a.v[2], -a.v[3]);
 }
 
 static inline xquat xquat_nlerp(xquat a, xquat b, xint t){
@@ -1841,12 +2009,12 @@ static inline xquat xquat_normal(xquat a){
 		len = xint_sqrt(len);
 		if (len > 0){
 			len = xint_div(XINT1, len);
-			return (xquat){
+			return xquat_new(
 				xint_mul(ax, len),
 				xint_mul(ay, len),
 				xint_mul(az, len),
 				xint_mul(aw, len)
-			};
+			);
 		}
 	}
 	return a;
@@ -1875,12 +2043,12 @@ static inline xquat xquat_slerp(xquat a, xquat b, xint t){
 		scale0 = xint_sub(XINT1, t);
 		scale1 = t;
 	}
-	return (xquat){
+	return xquat_new(
 		xint_add(xint_mul(scale0, ax), xint_mul(scale1, bx)),
 		xint_add(xint_mul(scale0, ay), xint_mul(scale1, by)),
 		xint_add(xint_mul(scale0, az), xint_mul(scale1, bz)),
 		xint_add(xint_mul(scale0, aw), xint_mul(scale1, bw))
-	};
+	);
 }
 
 //
@@ -1889,44 +2057,44 @@ static inline xquat xquat_slerp(xquat a, xquat b, xint t){
 
 #ifndef NVQM_SKIP_FLOATING_POINT
 static inline mat2 xmat2_tomat2(xmat2 a){
-	return (mat2){
+	return mat2_new(
 		xint_tofloat(a.v[0]),
 		xint_tofloat(a.v[1]),
 		xint_tofloat(a.v[2]),
 		xint_tofloat(a.v[3])
-	};
+	);
 }
 
 static inline xmat2 xmat2_frommat2(mat2 a){
-	return (xmat2){
+	return xmat2_new(
 		xint_fromfloat(a.v[0]),
 		xint_fromfloat(a.v[1]),
 		xint_fromfloat(a.v[2]),
 		xint_fromfloat(a.v[3])
-	};
+	);
 }
 #endif
 
 static inline xmat2 xmat2_add(xmat2 a, xmat2 b){
-	return (xmat2){
+	return xmat2_new(
 		xint_add(a.v[0], b.v[0]),
 		xint_add(a.v[1], b.v[1]),
 		xint_add(a.v[2], b.v[2]),
 		xint_add(a.v[3], b.v[3])
-	};
+	);
 }
 
 static inline xmat2 xmat2_adjoint(xmat2 a){
-	return (xmat2){ a.v[3], -a.v[1], -a.v[2], a.v[0] };
+	return xmat2_new(a.v[3], -a.v[1], -a.v[2], a.v[0]);
 }
 
 static inline xmat2 xmat2_compmul(xmat2 a, xmat2 b){
-	return (xmat2){
+	return xmat2_new(
 		xint_mul(a.v[0], b.v[0]),
 		xint_mul(a.v[1], b.v[1]),
 		xint_mul(a.v[2], b.v[2]),
 		xint_mul(a.v[3], b.v[3])
-	};
+	);
 }
 
 static inline xint xmat2_det(xmat2 a){
@@ -1934,72 +2102,72 @@ static inline xint xmat2_det(xmat2 a){
 }
 
 static inline xmat2 xmat2_identity(){
-	return (xmat2){ XINT1, 0, 0, XINT1 };
+	return xmat2_new(XINT1, 0, 0, XINT1);
 }
 
 static inline xmat2 xmat2_invert(xmat2 a){
 	xint a0 = a.v[0], a1 = a.v[1], a2 = a.v[2], a3 = a.v[3];
 	xint det = xint_sub(xint_mul(a0, a3), xint_mul(a2, a1));
 	if (det == 0)
-		return (xmat2){ 0, 0, 0, 0 };
+		return xmat2_new(0, 0, 0, 0);
 	det = xint_div(XINT1, det);
-	return (xmat2){
+	return xmat2_new(
 		 xint_mul(a3, det),
 		-xint_mul(a1, det),
 		-xint_mul(a2, det),
 		 xint_mul(a0, det)
-	};
+	);
 }
 
 static inline xmat2 xmat2_mul(xmat2 a, xmat2 b){
 	xint
 		a0 = a.v[0], a1 = a.v[1], a2 = a.v[2], a3 = a.v[3],
 		b0 = b.v[0], b1 = b.v[1], b2 = b.v[2], b3 = b.v[3];
-	return (xmat2){
+	return xmat2_new(
 		xint_add(xint_mul(a0, b0), xint_mul(a2, b1)),
 		xint_add(xint_mul(a1, b0), xint_mul(a3, b1)),
 		xint_add(xint_mul(a0, b2), xint_mul(a2, b3)),
 		xint_add(xint_mul(a1, b2), xint_mul(a3, b3))
-	};
+	);
 }
 
 static inline xmat2 xmat2_rotate(xmat2 a, xang ang){
 	xint a0 = a.v[0], a1 = a.v[1], a2 = a.v[2], a3 = a.v[3], s = xint_sin(ang), c = xint_cos(ang);
-	return (xmat2){
+	return xmat2_new(
 		xint_add(xint_mul(a0,  c), xint_mul(a2, s)),
 		xint_add(xint_mul(a1,  c), xint_mul(a3, s)),
 		xint_add(xint_mul(a0, -s), xint_mul(a2, c)),
 		xint_add(xint_mul(a1, -s), xint_mul(a3, c))
-	};
+	);
 }
 
 static inline xmat2 xmat2_rotation(xang ang){
 	xint s = xint_sin(ang), c = xint_cos(ang);
-	return (xmat2){ c, s, -s, c };
+	return xmat2_new(c, s, -s, c);
 }
 
 static inline xmat2 xmat2_scale(xmat2 a, xvec2 b){
 	xint
 		a0 = a.v[0], a1 = a.v[1], a2 = a.v[2], a3 = a.v[3],
 		b0 = b.v[0], b1 = b.v[1];
-	return (xmat2){ xint_mul(a0, b0), xint_mul(a1, b0), xint_mul(a2, b1), xint_mul(a3, b1) };
+	return xmat2_new(xint_mul(a0, b0), xint_mul(a1, b0), xint_mul(a2, b1), xint_mul(a3, b1));
 }
 
 static inline xmat2 xmat2_scaling(xvec2 a){
-	return (xmat2){ a.v[0], 0, 0, a.v[1] };
+	return xmat2_new(a.v[0], 0, 0, a.v[1]);
 }
 
 static inline xmat2 xmat2_sub(xmat2 a, xmat2 b){
-	return (xmat2){
+	return xmat2_new(
 		xint_sub(a.v[0], b.v[0]),
 		xint_sub(a.v[1], b.v[1]),
 		xint_sub(a.v[2], b.v[2]),
 		xint_sub(a.v[3], b.v[3])
-	};
+	);
 }
 
 static inline xmat2 xmat2_transpose(xmat2 a){
-	return (xmat2){ a.v[0], a.v[2], a.v[1], a.v[3] };
+	return xmat2_new(a.v[0], a.v[2], a.v[1], a.v[3]);
 }
 
 //
@@ -2008,42 +2176,42 @@ static inline xmat2 xmat2_transpose(xmat2 a){
 
 #ifndef NVQM_SKIP_FLOATING_POINT
 static inline mat3x2 xmat3x2_tomat3x2(xmat3x2 a){
-	return (mat3x2){
+	return mat3x2_new(
 		xint_tofloat(a.v[0]),
 		xint_tofloat(a.v[1]),
 		xint_tofloat(a.v[2]),
 		xint_tofloat(a.v[3]),
 		xint_tofloat(a.v[4]),
 		xint_tofloat(a.v[5])
-	};
+	);
 }
 
 static inline xmat3x2 xmat3x2_frommat3x2(mat3x2 a){
-	return (xmat3x2){
+	return xmat3x2_new(
 		xint_fromfloat(a.v[0]),
 		xint_fromfloat(a.v[1]),
 		xint_fromfloat(a.v[2]),
 		xint_fromfloat(a.v[3]),
 		xint_fromfloat(a.v[4]),
 		xint_fromfloat(a.v[5])
-	};
+	);
 }
 #endif
 
 static inline xmat3x2 xmat3x2_add(xmat3x2 a, xmat3x2 b){
-	return (xmat3x2){
+	return xmat3x2_new(
 		xint_add(a.v[0], b.v[0]), xint_add(a.v[1], b.v[1]),
 		xint_add(a.v[2], b.v[2]), xint_add(a.v[3], b.v[3]),
 		xint_add(a.v[4], b.v[4]), xint_add(a.v[5], b.v[5])
-	};
+	);
 }
 
 static inline xmat3x2 xmat3x2_compmul(xmat3x2 a, xmat3x2 b){
-	return (xmat3x2){
+	return xmat3x2_new(
 		xint_mul(a.v[0], b.v[0]), xint_mul(a.v[1], b.v[1]),
 		xint_mul(a.v[2], b.v[2]), xint_mul(a.v[3], b.v[3]),
 		xint_mul(a.v[4], b.v[4]), xint_mul(a.v[5], b.v[5])
-	};
+	);
 }
 
 static inline xint xmat3x2_det(xmat3x2 a){
@@ -2051,7 +2219,7 @@ static inline xint xmat3x2_det(xmat3x2 a){
 }
 
 static inline xmat3x2 xmat3x2_identity(){
-	return (xmat3x2){ XINT1, 0, 0, XINT1, 0, 0 };
+	return xmat3x2_new(XINT1, 0, 0, XINT1, 0, 0);
 }
 
 static inline xmat3x2 xmat3x2_invert(xmat3x2 a){
@@ -2061,14 +2229,14 @@ static inline xmat3x2 xmat3x2_invert(xmat3x2 a){
 		a20 = a.v[4], a21 = a.v[5];
 	xint det = a00 * a11 - a01 * a10;
 	if (det == 0)
-		return (xmat3x2){ 0, 0, 0, 0, 0, 0 };
+		return xmat3x2_new(0, 0, 0, 0, 0, 0);
 	det = xint_div(XINT1, det);
-	return (xmat3x2){
+	return xmat3x2_new(
 		xint_mul( a11, det), xint_mul(-a01, det),
 		xint_mul(-a10, det), xint_mul( a00, det),
 		xint_mul(xint_sub(xint_mul( a21, a10), xint_mul(a11, a20)), det),
 		xint_mul(xint_add(xint_mul(-a21, a00), xint_mul(a01, a20)), det)
-	};
+	);
 }
 
 static inline xmat3x2 xmat3x2_mul(xmat3x2 a, xmat3x2 b){
@@ -2079,14 +2247,14 @@ static inline xmat3x2 xmat3x2_mul(xmat3x2 a, xmat3x2 b){
 		b00 = b.v[0], b01 = b.v[1],
 		b10 = b.v[2], b11 = b.v[3],
 		b20 = b.v[4], b21 = b.v[5];
-	return (xmat3x2){
+	return xmat3x2_new(
 		xint_add(xint_mul(b00, a00), xint_mul(b01, a10)),
 		xint_add(xint_mul(b00, a01), xint_mul(b01, a11)),
 		xint_add(xint_mul(b10, a00), xint_mul(b11, a10)),
 		xint_add(xint_mul(b10, a01), xint_mul(b11, a11)),
 		xint_add(xint_add(xint_mul(b20, a00), xint_mul(b21, a10)), a20),
 		xint_add(xint_add(xint_mul(b20, a01), xint_mul(b21, a11)), a21)
-	};
+	);
 }
 
 static inline xmat3x2 xmat3x2_rotate(xmat3x2 a, xang ang){
@@ -2094,37 +2262,37 @@ static inline xmat3x2 xmat3x2_rotate(xmat3x2 a, xang ang){
 		a00 = a.v[0], a01 = a.v[1],
 		a10 = a.v[2], a11 = a.v[3],
 		s = xint_sin(ang), c = xint_cos(ang);
-	return (xmat3x2){
+	return xmat3x2_new(
 		xint_add(xint_mul(c, a00), xint_mul(s, a10)), xint_add(xint_mul(c, a01), xint_mul(s, a11)),
 		xint_sub(xint_mul(c, a10), xint_mul(s, a00)), xint_sub(xint_mul(c, a11), xint_mul(s, a01)),
 		a.v[4], a.v[5]
-	};
+	);
 }
 
 static inline xmat3x2 xmat3x2_rotation(xang ang){
 	xint s = xint_sin(ang), c = xint_cos(ang);
-	return (xmat3x2){ c, s, -s, c, 0, 0 };
+	return xmat3x2_new(c, s, -s, c, 0, 0);
 }
 
 static inline xmat3x2 xmat3x2_scale(xmat3x2 a, xvec2 b){
 	xint bx = b.v[0], by = b.v[1];
-	return (xmat3x2){
+	return xmat3x2_new(
 		xint_mul(bx, a.v[0]), xint_mul(bx, a.v[1]),
 		xint_mul(by, a.v[2]), xint_mul(by, a.v[3]),
-		a.v[4], a.v[5],
-	};
+		a.v[4], a.v[5]
+	);
 }
 
 static inline xmat3x2 xmat3x2_scaling(xvec2 a){
-	return (xmat3x2){ a.v[0], 0, 0, a.v[1], 0, 0 };
+	return xmat3x2_new(a.v[0], 0, 0, a.v[1], 0, 0);
 }
 
 static inline xmat3x2 xmat3x2_sub(xmat3x2 a, xmat3x2 b){
-	return (xmat3x2){
+	return xmat3x2_new(
 		xint_sub(a.v[0], b.v[0]), xint_sub(a.v[1], b.v[1]),
 		xint_sub(a.v[2], b.v[2]), xint_sub(a.v[3], b.v[3]),
 		xint_sub(a.v[4], b.v[4]), xint_sub(a.v[5], b.v[5])
-	};
+	);
 }
 
 static inline xmat3x2 xmat3x2_translate(xmat3x2 a, xvec2 b){
@@ -2132,16 +2300,16 @@ static inline xmat3x2 xmat3x2_translate(xmat3x2 a, xvec2 b){
 		a00 = a.v[0], a01 = a.v[1],
 		a10 = a.v[2], a11 = a.v[3],
 		bx = b.v[0], by = b.v[1];
-	return (xmat3x2){
+	return xmat3x2_new(
 		a00, a01,
 		a10, a11,
 		xint_add(xint_add(xint_mul(bx, a00), xint_mul(by, a10)), a.v[4]),
 		xint_add(xint_add(xint_mul(bx, a01), xint_mul(by, a11)), a.v[5])
-	};
+	);
 }
 
 static inline xmat3x2 xmat3x2_translation(xvec2 a){
-	return (xmat3x2){ XINT1, 0, 0, XINT1, a.v[0], a.v[1] };
+	return xmat3x2_new(XINT1, 0, 0, XINT1, a.v[0], a.v[1]);
 }
 
 //

--- a/nvqm.h
+++ b/nvqm.h
@@ -15,10 +15,17 @@
 // 32-bit floating point
 //
 
+#ifndef NVQM_SKIP_COMPONENT_NAMES
+typedef union { float v[ 2]; struct { float x; float y; };                   struct { float r; float g; };                   struct { float s; float t; };                   } vec2;
+typedef union { float v[ 3]; struct { float x; float y; float z; };          struct { float r; float g; float b; };          struct { float s; float t; float p; };          } vec3;
+typedef union { float v[ 4]; struct { float x; float y; float z; float w; }; struct { float r; float g; float b; float a; }; struct { float s; float t; float p; float q; }; } vec4;
+typedef union { float v[ 4]; struct { float x; float y; float z; float w; }; struct { float s; float i; float j; float k; }; } quat;
+#else
 typedef struct { float v[ 2]; } vec2;
 typedef struct { float v[ 3]; } vec3;
 typedef struct { float v[ 4]; } vec4;
 typedef struct { float v[ 4]; } quat;
+#endif
 typedef struct { float v[ 4]; } mat2;
 typedef struct { float v[ 6]; } mat3x2;
 typedef struct { float v[ 9]; } mat3;
@@ -1032,10 +1039,17 @@ mat4 *mat4_transpose     (mat4 *out, mat4 *a);
 
 // signed 16.16 fixed-point
 typedef int32_t xint;
+#ifndef NVQM_SKIP_COMPONENT_NAMES
+typedef union { xint v[ 2]; struct { xint x; xint y; };                 struct { xint r; xint g; };                 struct { xint s; xint t; };                 } xvec2;
+typedef union { xint v[ 3]; struct { xint x; xint y; xint z; };         struct { xint r; xint g; xint b; };         struct { xint s; xint t; xint p; };         } xvec3;
+typedef union { xint v[ 4]; struct { xint x; xint y; xint z; xint w; }; struct { xint r; xint g; xint b; xint a; }; struct { xint s; xint t; xint p; xint q; }; } xvec4;
+typedef union { xint v[ 4]; struct { xint x; xint y; xint z; xint w; }; struct { xint s; xint i; xint j; xint k; }; } xquat;
+#else
 typedef struct { xint v[ 2]; } xvec2;
 typedef struct { xint v[ 3]; } xvec3;
 typedef struct { xint v[ 4]; } xvec4;
 typedef struct { xint v[ 4]; } xquat;
+#endif
 typedef struct { xint v[ 4]; } xmat2;
 typedef struct { xint v[ 6]; } xmat3x2;
 typedef struct { xint v[ 9]; } xmat3;


### PR DESCRIPTION
 * Allow compiling with ANSI C standard `cc -Dinline= -std=c89 nvqm.c -lm` without warnings
 * Fixes a warning by adding explicit initializer functions
 * Optionally adds component name accessors
 
 Component name accessors are not standard C, but are supported by most compilers, and on most (all?) targets. DirectX also uses this trick.